### PR TITLE
Added ons to wordlist

### DIFF
--- a/.github/config/.wordlist.txt
+++ b/.github/config/.wordlist.txt
@@ -39,6 +39,7 @@ msrc
 MSRC
 NewVNet
 onboardsupport
+ons
 opencode
 operationalization
 pgandham


### PR DESCRIPTION
Looks like the rename to Add-ons failed the spellcheck somewhere, this should resolve it.