### PR TITLE
Using param() blocks - example

### DIFF
--- a/Scenarios/Networking/AVS-to-VNet-ExistingVNet/PowerShell/Deploy-ExRConnection-GenerateAuthKey.ps1
+++ b/Scenarios/Networking/AVS-to-VNet-ExistingVNet/PowerShell/Deploy-ExRConnection-GenerateAuthKey.ps1
@@ -1,10 +1,32 @@
 # Parameters for deployment
-$privateCloudName = "ExamplePrivateCloud"
-$PrivateCloudResourceGroup = "ExampleResourceGroup"
-$GatewayName = "ExampleGatewayName"
-$GatewayResourceGroup = "ExampleGatewayResourceGroup"
-$location = "ExampleLocation"
-$ConnectionName = "$privateCloudNameer-ExR-Connection"
+param(
+    [Parameter(Mandatory=$true)]
+    [String]
+    # The name of your (existing) private cloud
+    $privateCloudName,
+
+    [Parameter(Mandatory=$true)]
+    [String]
+    # The name of your (existing) private cloud's resource group
+    $PrivateCloudResourceGroup,
+    
+    [Parameter(Mandatory=$true)]
+    [String]
+    # The name of the (existing) ER Gateway
+    $GatewayName,
+    
+    [Parameter(Mandatory=$true)]
+    [String]
+    # The name of the (existing) ER Gateway's resource group
+    $GatewayResourceGroup,
+    
+    [Parameter(Mandatory=$true)]
+    [String]
+    # The Azure region for the connection resource
+    $location
+)
+
+$ConnectionName = "$privateCloudName-ExR-Connection"
 
 # Get Private Cloud and create ExR authorisation key, must be a circuit owner
 $privatecloud = Get-AzVMwarePrivateCloud -Name $privateCloudName -ResourceGroupName $PrivateCloudResourceGroup


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

This PR provides an example of how to use param() blocks to make it possible to pass parameter values to the script without editing it. It is just an example - no need to actually merge.

## This PR fixes/adds/changes/removes

1. Replaces variables with parameters

### Breaking Changes

1. The suggested approach allows passing parameters to the script when calling it, instead of editing the script itself to set variables.

## Testing Evidence

- This is just an example. No e2e testing has been done. Do not merge.

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale-for-AVS/pulls)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale-for-AVS/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
