### PR TITLE
Added upgrade check to arm build script

### DIFF
--- a/.github/workflows/armbuild.yml
+++ b/.github/workflows/armbuild.yml
@@ -1,0 +1,21 @@
+name: ARM Build Action
+on: push
+
+jobs:
+  build:
+    name: ARM
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Run Build-ARM.ps1
+      uses: azure/powershell@v1
+      with:
+        inlineScript: |
+          ./Build-ARM.ps1
+          $changes = git status --porcelain
+          if ($changes) {
+            Write-Host $changes
+            Write-Error "ARM templates are out of date!" -ErrorAction stop
+          }
+          Write-Host "ARM templates are up to date."
+        azPSVersion: "latest"

--- a/Build-ARM.ps1
+++ b/Build-ARM.ps1
@@ -1,3 +1,9 @@
+Write-Host "Checking for Bicep updates..."
+& az bicep upgrade
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Error whilst upgrading Bicep, is the Azure CLI & Bicep installed?" -ErrorAction Stop
+}
+
 Get-ChildItem '.\' -Recurse -Include '*.bicep' |% {
     $source = $_.FullName
     if (!($source -like "*\Bicep\Modules\*") -and !($source -like "*/Bicep/Modules/*") -and !($source -like "*999-WorkInProgress*")) { 
@@ -8,6 +14,9 @@ Get-ChildItem '.\' -Recurse -Include '*.bicep' |% {
         $bicepParams = Join-Path $folder "Bicep\$($name).parameters.json"
         Write-Host "Building $name in $($folder.Name)"
         & az bicep build -f "$source" --outfile "$target"
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "Unable to build $($name)!" -ErrorAction Stop
+        }
         if (!(Test-Path $targetParams)) {
             Set-Content -Path $targetParams -Value ""
         }


### PR DESCRIPTION
This change adds an upgrade check to the ARM-Build.ps1 script, ensuring each build of the ARM templates is using the latest version.

As upgrade lives within the bicep Azure CLI module, if the user does not have Azure CLI or Bicep installed, it will now exit early and show the reason.