### PR TITLE
Add Customer Attribution to Brownfield Scenarios

### DIFF
--- a/AVS-Landing-Zone/GreenField/ARM/ESLZDeploy.deploy.json
+++ b/AVS-Landing-Zone/GreenField/ARM/ESLZDeploy.deploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1124.51302",
-      "templateHash": "7168082195424275913"
+      "version": "0.4.1272.37030",
+      "templateHash": "12562905128307787198"
     }
   },
   "parameters": {
@@ -170,8 +170,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1124.51302",
-              "templateHash": "15378880053067632785"
+              "version": "0.4.1272.37030",
+              "templateHash": "15172318823083807896"
             }
           },
           "parameters": {
@@ -225,8 +225,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1124.51302",
-                      "templateHash": "10655832318723376968"
+                      "version": "0.4.1272.37030",
+                      "templateHash": "7093807809607086474"
                     }
                   },
                   "parameters": {
@@ -299,7 +299,7 @@
           "outputs": {
             "PrivateCloudName": {
               "type": "string",
-              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-PrivateCloud', parameters('Prefix'))), 'Microsoft.Resources/deployments', format('{0}-PrivateCloud', deployment().name)), '2020-10-01').outputs.PrivateCloudName.value]"
+              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-PrivateCloud', parameters('Prefix'))), 'Microsoft.Resources/deployments', format('{0}-PrivateCloud', deployment().name))).outputs.PrivateCloudName.value]"
             },
             "PrivateCloudResourceGroupName": {
               "type": "string",
@@ -307,7 +307,7 @@
             },
             "PrivateCloudResourceId": {
               "type": "string",
-              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-PrivateCloud', parameters('Prefix'))), 'Microsoft.Resources/deployments', format('{0}-PrivateCloud', deployment().name)), '2020-10-01').outputs.PrivateCloudResourceId.value]"
+              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-PrivateCloud', parameters('Prefix'))), 'Microsoft.Resources/deployments', format('{0}-PrivateCloud', deployment().name))).outputs.PrivateCloudResourceId.value]"
             }
           }
         }
@@ -346,8 +346,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1124.51302",
-              "templateHash": "7368983108761547608"
+              "version": "0.4.1272.37030",
+              "templateHash": "5168640292298644792"
             }
           },
           "parameters": {
@@ -407,8 +407,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1124.51302",
-                      "templateHash": "3880261043408495851"
+                      "version": "0.4.1272.37030",
+                      "templateHash": "16315569410178072104"
                     }
                   },
                   "parameters": {
@@ -535,15 +535,15 @@
           "outputs": {
             "GatewayName": {
               "type": "string",
-              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-Network', parameters('Prefix'))), 'Microsoft.Resources/deployments', format('{0}-Network', deployment().name)), '2020-10-01').outputs.GatewayName.value]"
+              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-Network', parameters('Prefix'))), 'Microsoft.Resources/deployments', format('{0}-Network', deployment().name))).outputs.GatewayName.value]"
             },
             "VNetName": {
               "type": "string",
-              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-Network', parameters('Prefix'))), 'Microsoft.Resources/deployments', format('{0}-Network', deployment().name)), '2020-10-01').outputs.VNetName.value]"
+              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-Network', parameters('Prefix'))), 'Microsoft.Resources/deployments', format('{0}-Network', deployment().name))).outputs.VNetName.value]"
             },
             "VNetResourceId": {
               "type": "string",
-              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-Network', parameters('Prefix'))), 'Microsoft.Resources/deployments', format('{0}-Network', deployment().name)), '2020-10-01').outputs.VNetResourceId.value]"
+              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-Network', parameters('Prefix'))), 'Microsoft.Resources/deployments', format('{0}-Network', deployment().name))).outputs.VNetResourceId.value]"
             },
             "NetworkResourceGroup": {
               "type": "string",
@@ -565,19 +565,19 @@
         "mode": "Incremental",
         "parameters": {
           "GatewayName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-Network', variables('deploymentPrefix'))), '2020-10-01').outputs.GatewayName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-Network', variables('deploymentPrefix')))).outputs.GatewayName.value]"
           },
           "NetworkResourceGroup": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-Network', variables('deploymentPrefix'))), '2020-10-01').outputs.NetworkResourceGroup.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-Network', variables('deploymentPrefix')))).outputs.NetworkResourceGroup.value]"
           },
           "VNetPrefix": {
             "value": "[parameters('Prefix')]"
           },
           "PrivateCloudName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-AVS', variables('deploymentPrefix'))), '2020-10-01').outputs.PrivateCloudName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-AVS', variables('deploymentPrefix')))).outputs.PrivateCloudName.value]"
           },
           "PrivateCloudResourceGroup": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-AVS', variables('deploymentPrefix'))), '2020-10-01').outputs.PrivateCloudResourceGroupName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-AVS', variables('deploymentPrefix')))).outputs.PrivateCloudResourceGroupName.value]"
           }
         },
         "template": {
@@ -586,8 +586,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1124.51302",
-              "templateHash": "7598832840845051085"
+              "version": "0.4.1272.37030",
+              "templateHash": "8542497997471237573"
             }
           },
           "parameters": {
@@ -636,8 +636,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1124.51302",
-                      "templateHash": "15060005432177066652"
+                      "version": "0.4.1272.37030",
+                      "templateHash": "5131100314591469562"
                     }
                   },
                   "parameters": {
@@ -686,10 +686,10 @@
                     "value": "[parameters('GatewayName')]"
                   },
                   "ExpressRouteAuthorizationKey": {
-                    "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('PrivateCloudResourceGroup')), 'Microsoft.Resources/deployments', format('{0}-ExRAuth', deployment().name)), '2020-10-01').outputs.ExpressRouteAuthorizationKey.value]"
+                    "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('PrivateCloudResourceGroup')), 'Microsoft.Resources/deployments', format('{0}-ExRAuth', deployment().name))).outputs.ExpressRouteAuthorizationKey.value]"
                   },
                   "ExpressRouteId": {
-                    "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('PrivateCloudResourceGroup')), 'Microsoft.Resources/deployments', format('{0}-ExRAuth', deployment().name)), '2020-10-01').outputs.ExpressRouteId.value]"
+                    "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('PrivateCloudResourceGroup')), 'Microsoft.Resources/deployments', format('{0}-ExRAuth', deployment().name))).outputs.ExpressRouteId.value]"
                   }
                 },
                 "template": {
@@ -698,8 +698,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1124.51302",
-                      "templateHash": "11503780935298458269"
+                      "version": "0.4.1272.37030",
+                      "templateHash": "2673651195166983330"
                     }
                   },
                   "parameters": {
@@ -756,7 +756,7 @@
           "outputs": {
             "ExRConnectionResourceId": {
               "type": "string",
-              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('NetworkResourceGroup')), 'Microsoft.Resources/deployments', format('{0}-ExR', deployment().name)), '2020-10-01').outputs.ExRConnectionResourceId.value]"
+              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('NetworkResourceGroup')), 'Microsoft.Resources/deployments', format('{0}-ExR', deployment().name))).outputs.ExRConnectionResourceId.value]"
             }
           }
         }
@@ -778,10 +778,10 @@
         "mode": "Incremental",
         "parameters": {
           "PrivateCloudName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-AVS', variables('deploymentPrefix'))), '2020-10-01').outputs.PrivateCloudName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-AVS', variables('deploymentPrefix')))).outputs.PrivateCloudName.value]"
           },
           "PrivateCloudResourceGroup": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-AVS', variables('deploymentPrefix'))), '2020-10-01').outputs.PrivateCloudResourceGroupName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-AVS', variables('deploymentPrefix')))).outputs.PrivateCloudResourceGroupName.value]"
           },
           "DeployHCX": {
             "value": "[parameters('DeployHCX')]"
@@ -802,8 +802,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1124.51302",
-              "templateHash": "7217257512543135805"
+              "version": "0.4.1272.37030",
+              "templateHash": "11346226735746445858"
             }
           },
           "parameters": {
@@ -851,8 +851,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1124.51302",
-                      "templateHash": "273576938513755529"
+                      "version": "0.4.1272.37030",
+                      "templateHash": "9414882336870263525"
                     }
                   },
                   "parameters": {
@@ -902,8 +902,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1124.51302",
-                      "templateHash": "16880892312940129911"
+                      "version": "0.4.1272.37030",
+                      "templateHash": "15030845292505242552"
                     }
                   },
                   "parameters": {
@@ -977,10 +977,10 @@
             "value": "[parameters('JumpboxPassword')]"
           },
           "VNetName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-Network', variables('deploymentPrefix'))), '2020-10-01').outputs.VNetName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-Network', variables('deploymentPrefix')))).outputs.VNetName.value]"
           },
           "VNetResourceGroup": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-Network', variables('deploymentPrefix'))), '2020-10-01').outputs.NetworkResourceGroup.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-Network', variables('deploymentPrefix')))).outputs.NetworkResourceGroup.value]"
           },
           "BastionSubnet": {
             "value": "[parameters('BastionSubnet')]"
@@ -998,8 +998,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1124.51302",
-              "templateHash": "1019847444772224258"
+              "version": "0.4.1272.37030",
+              "templateHash": "10529528804814564462"
             }
           },
           "parameters": {
@@ -1065,8 +1065,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1124.51302",
-                      "templateHash": "8889610772781876406"
+                      "version": "0.4.1272.37030",
+                      "templateHash": "17467368030579511932"
                     }
                   },
                   "parameters": {
@@ -1129,7 +1129,7 @@
                     "value": "[parameters('Prefix')]"
                   },
                   "SubnetId": {
-                    "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('VNetResourceGroup')), 'Microsoft.Resources/deployments', 'Jumpbox-Subnet'), '2020-10-01').outputs.BastionSubnetId.value]"
+                    "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('VNetResourceGroup')), 'Microsoft.Resources/deployments', 'Jumpbox-Subnet')).outputs.BastionSubnetId.value]"
                   },
                   "Location": {
                     "value": "[parameters('Location')]"
@@ -1141,8 +1141,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1124.51302",
-                      "templateHash": "11205957976555163374"
+                      "version": "0.4.1272.37030",
+                      "templateHash": "10220434693285855200"
                     }
                   },
                   "parameters": {
@@ -1217,7 +1217,7 @@
                     "value": "[parameters('Prefix')]"
                   },
                   "SubnetId": {
-                    "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('VNetResourceGroup')), 'Microsoft.Resources/deployments', 'Jumpbox-Subnet'), '2020-10-01').outputs.JumpBoxSubnetId.value]"
+                    "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('VNetResourceGroup')), 'Microsoft.Resources/deployments', 'Jumpbox-Subnet')).outputs.JumpBoxSubnetId.value]"
                   },
                   "Location": {
                     "value": "[parameters('Location')]"
@@ -1238,8 +1238,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1124.51302",
-                      "templateHash": "4533167628304018150"
+                      "version": "0.4.1272.37030",
+                      "templateHash": "7628283438743169095"
                     }
                   },
                   "parameters": {
@@ -1349,7 +1349,7 @@
           "outputs": {
             "JumpboxResourceId": {
               "type": "string",
-              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-Jumpbox', parameters('Prefix'))), 'Microsoft.Resources/deployments', format('{0}-VM', deployment().name)), '2020-10-01').outputs.JumpboxResourceId.value]"
+              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-Jumpbox', parameters('Prefix'))), 'Microsoft.Resources/deployments', format('{0}-VM', deployment().name))).outputs.JumpboxResourceId.value]"
             }
           }
         }
@@ -1379,19 +1379,19 @@
             "value": "[parameters('Location')]"
           },
           "PrimaryPrivateCloudName": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-AVS', variables('deploymentPrefix'))), '2020-10-01').outputs.PrivateCloudName.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-AVS', variables('deploymentPrefix')))).outputs.PrivateCloudName.value]"
           },
           "PrimaryPrivateCloudResourceId": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-AVS', variables('deploymentPrefix'))), '2020-10-01').outputs.PrivateCloudResourceId.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-AVS', variables('deploymentPrefix')))).outputs.PrivateCloudResourceId.value]"
           },
           "JumpboxResourceId": {
-            "value": "[if(parameters('DeployJumpbox'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-Jumpbox', variables('deploymentPrefix'))), '2020-10-01').outputs.JumpboxResourceId.value, '')]"
+            "value": "[if(parameters('DeployJumpbox'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-Jumpbox', variables('deploymentPrefix')))).outputs.JumpboxResourceId.value, '')]"
           },
           "VNetResourceId": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-Network', variables('deploymentPrefix'))), '2020-10-01').outputs.VNetResourceId.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-Network', variables('deploymentPrefix')))).outputs.VNetResourceId.value]"
           },
           "ExRConnectionResourceId": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-VNet', variables('deploymentPrefix'))), '2020-10-01').outputs.ExRConnectionResourceId.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-VNet', variables('deploymentPrefix')))).outputs.ExRConnectionResourceId.value]"
           }
         },
         "template": {
@@ -1400,8 +1400,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1124.51302",
-              "templateHash": "2222937430635092807"
+              "version": "0.4.1272.37030",
+              "templateHash": "2829467024668368261"
             }
           },
           "parameters": {
@@ -1461,8 +1461,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1124.51302",
-                      "templateHash": "15565533722942890520"
+                      "version": "0.4.1272.37030",
+                      "templateHash": "10234831864174728285"
                     }
                   },
                   "parameters": {
@@ -1521,7 +1521,7 @@
                 "mode": "Incremental",
                 "parameters": {
                   "ActionGroupResourceId": {
-                    "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-Operational', parameters('Prefix'))), 'Microsoft.Resources/deployments', format('{0}-ActionGroup', deployment().name)), '2020-10-01').outputs.ActionGroupResourceId.value]"
+                    "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-Operational', parameters('Prefix'))), 'Microsoft.Resources/deployments', format('{0}-ActionGroup', deployment().name))).outputs.ActionGroupResourceId.value]"
                   },
                   "AlertPrefix": {
                     "value": "[parameters('PrimaryPrivateCloudName')]"
@@ -1536,8 +1536,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1124.51302",
-                      "templateHash": "6250900084495025713"
+                      "version": "0.4.1272.37030",
+                      "templateHash": "1157840457735554270"
                     }
                   },
                   "parameters": {
@@ -1656,7 +1656,7 @@
                 "mode": "Incremental",
                 "parameters": {
                   "ActionGroupResourceId": {
-                    "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-Operational', parameters('Prefix'))), 'Microsoft.Resources/deployments', format('{0}-ActionGroup', deployment().name)), '2020-10-01').outputs.ActionGroupResourceId.value]"
+                    "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-Operational', parameters('Prefix'))), 'Microsoft.Resources/deployments', format('{0}-ActionGroup', deployment().name))).outputs.ActionGroupResourceId.value]"
                   },
                   "AlertPrefix": {
                     "value": "[parameters('PrimaryPrivateCloudName')]"
@@ -1671,8 +1671,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1124.51302",
-                      "templateHash": "18097017464112028991"
+                      "version": "0.4.1272.37030",
+                      "templateHash": "13524405542818990110"
                     }
                   },
                   "parameters": {
@@ -1772,8 +1772,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1124.51302",
-                      "templateHash": "13849737411533743855"
+                      "version": "0.4.1272.37030",
+                      "templateHash": "16075589945352224887"
                     }
                   },
                   "parameters": {

--- a/BrownField/Addons/CUAID/customerUsageAttribution/README.md
+++ b/BrownField/Addons/CUAID/customerUsageAttribution/README.md
@@ -1,0 +1,25 @@
+# Module: PID
+
+This module creates a blank deployment which will be called from other modules. The purpose of this deployment is to create a deployment name to be used for Azure [customer usage attribution](https://docs.microsoft.com/azure/marketplace/azure-partner-customer-usage-attribution). To disable this, please see [How to disable Telemetry Tracking Using Customer Usage Attribution (PID)](https://github.com/Azure/ALZ-Bicep/wiki/CustomerUsage)
+
+This module does not deploy any resources
+
+## Parameters
+
+This module does not require any inputs
+
+| Parameter | Type | Default | Description | Requirement | Example |
+| --------- | ---- | ------- | ----------- | ----------- | ------- |
+
+
+## Outputs
+
+The module does not generate any outputs
+
+| Output | Type | Example |
+| ------ | ---- | ------- |
+
+## Deployment
+
+This module is intended to be called from other modules as a reusable resource.
+

--- a/BrownField/Addons/CUAID/customerUsageAttribution/README.md
+++ b/BrownField/Addons/CUAID/customerUsageAttribution/README.md
@@ -21,5 +21,24 @@ The module does not generate any outputs
 
 ## Deployment
 
-This module is intended to be called from other modules as a reusable resource.
+This module is intended to be called from other modules as a reusable resource. 
 
+## Module PID Value Mapping
+
+The following are the unique ID's (also known as PIDs) used in each of the modules.
+
+| Module Name                                | PID                                  |
+| ------------------------------------------ | ------------------------------------ |
+| HCX                                        | ccdff80c-722d-42b7-8bd2-66aba33cba02 |
+| SRM                                        | c542e61c-1907-483f-9e18-76f5b85eee0a |
+| AVS-Dashboard                              | 6a449623-a5df-43f6-8df0-9b32dc2df958 |
+| AVS-Service-Health                         | a182f0f1-a209-42fd-aa05-e12bda423653 |
+| AVS-Utilization-Alerts                     | 6f7b68e9-1179-4853-9dfe-1a4f793b9893 |
+| AVS-to-AVS-CrossRegion-GlobalReach         | 1593acc2-6932-462b-af58-28f7fa9df52d |
+| AVS-to-AVS-SameRegion                      | 08d3edb1-3d70-4c0f-ab9f-f491b4a8d737 |
+| AVS-to-OnPremises-ExpressRoute-GlobalReach | 8fb78b9c-973d-45d1-bd35-fcad3c00e09e |
+| AVS-to-VNet-ExistingVNet                   | 9dd111b1-82f0-4104-bcf9-18b777f0c78f |
+| AVS-to-VNet-NewVNet                        | 938cd838-e22a-47da-8a6f-bdda923e3edb |
+| ExpressRoute-to-VNet                       | 174ca090-c796-4183-bc1f-ac6578e81d39 |
+| AVS-PrivateCloud-WithHCX                   | fe003615-ca8e-412f-8091-43e1e42ebfd8 |
+| AVS-PrivateCloud                           | 99f18c8b-1767-4302-9cee-ecc0d135dd52 |

--- a/BrownField/Addons/CUAID/customerUsageAttribution/bicepconfig.json
+++ b/BrownField/Addons/CUAID/customerUsageAttribution/bicepconfig.json
@@ -1,0 +1,64 @@
+{
+  "analyzers": {
+    "core": {
+      "enabled": true,
+      "verbose": true,
+      "rules": {
+        "adminusername-should-not-be-literal": {
+          "level": "error"
+        },
+        "no-hardcoded-env-urls": {
+          "level": "error"
+        },
+        "no-unnecessary-dependson": {
+          "level": "error"
+        },
+        "no-unused-params": {
+          "level": "error"
+        },
+        "no-unused-vars": {
+          "level": "error"
+        },
+        "outputs-should-not-contain-secrets": {
+          "level": "error"
+        },
+        "prefer-interpolation": {
+          "level": "error"
+        },
+        "secure-parameter-default": {
+          "level": "error"
+        },
+        "simplify-interpolation": {
+          "level": "error"
+        },
+        "protect-commandtoexecute-secrets": {
+          "level": "error"
+        },
+        "use-stable-vm-image": {
+          "level": "error"
+        },
+        "explicit-values-for-loc-params": {
+          "level": "error"
+        },
+        "no-hardcoded-location": {
+          "level": "error"
+        },
+        "no-loc-expr-outside-params": {
+          "level": "error"
+        },
+        "max-outputs": {
+          "level": "error"
+        },
+        "max-params": {
+          "level": "error"
+        },
+        "max-resources": {
+          "level": "error"
+        },
+        "max-variables": {
+          "level": "error"
+        }
+      }
+    }
+  }
+}

--- a/BrownField/Addons/CUAID/customerUsageAttribution/cuaIdManagementGroup.bicep
+++ b/BrownField/Addons/CUAID/customerUsageAttribution/cuaIdManagementGroup.bicep
@@ -1,0 +1,11 @@
+/*
+SUMMARY: Module to add the customer usage attribution (PID) to Management Group deployments.
+DESCRIPTION: This module will create a deployment at the management group level which will add the unique PID and location as the deployment name
+AUTHOR/S: shaunjacob
+VERSION: 1.0.0
+*/
+
+targetScope = 'managementGroup'
+
+// This is an empty deployment by design
+// Reference:  https://docs.microsoft.com/azure/marketplace/azure-partner-customer-usage-attribution

--- a/BrownField/Addons/CUAID/customerUsageAttribution/cuaIdResourceGroup.bicep
+++ b/BrownField/Addons/CUAID/customerUsageAttribution/cuaIdResourceGroup.bicep
@@ -1,0 +1,11 @@
+/*
+SUMMARY: Module to add the customer usage attribution (PID) to Resource Group deployments.
+DESCRIPTION: This module will create a deployment at the Resource Group level which will add the unique PID and location as the deployment name
+AUTHOR/S: shaunjacob
+VERSION: 1.0.0
+*/
+
+targetScope = 'resourceGroup'
+
+// This is an empty deployment by design
+// Reference:  https://docs.microsoft.com/azure/marketplace/azure-partner-customer-usage-attribution

--- a/BrownField/Addons/CUAID/customerUsageAttribution/cuaIdSubscription.bicep
+++ b/BrownField/Addons/CUAID/customerUsageAttribution/cuaIdSubscription.bicep
@@ -1,0 +1,11 @@
+/*
+SUMMARY: Module to add the customer usage attribution (PID) to Subscription deployments. 
+DESCRIPTION: This module will create a deployment at the Subscription level which will add the unique PID and location as the deployment name
+AUTHOR/S: shaunjacob
+VERSION: 1.0.0
+*/
+
+targetScope = 'subscription'
+
+// This is an empty deployment by design
+// Reference:  https://docs.microsoft.com/azure/marketplace/azure-partner-customer-usage-attribution

--- a/BrownField/Addons/CUAID/customerUsageAttribution/cuaIdTenant.bicep
+++ b/BrownField/Addons/CUAID/customerUsageAttribution/cuaIdTenant.bicep
@@ -1,0 +1,11 @@
+/*
+SUMMARY: Module to add the customer usage attribution (PID) to Tenant deployments.
+DESCRIPTION: This module will create a deployment at the Tenant level which will add the unique PID and location as the deployment name
+AUTHOR/S: shaunjacob
+VERSION: 1.0.0
+*/
+
+targetScope = 'tenant'
+
+// This is an empty deployment by design
+// Reference:  https://docs.microsoft.com/azure/marketplace/azure-partner-customer-usage-attribution

--- a/BrownField/Addons/CUAID/readme.md
+++ b/BrownField/Addons/CUAID/readme.md
@@ -1,0 +1,9 @@
+# Why Does This Directory Exist & Contain Other Modules?
+
+Good question! This directory exists to host modules that are **not** specific to the AVS Landing Zones modules that are contained within this repo.
+
+The modules inside this directory are modules that we are potentially planning, at some point in time, to remove from this repo and migrate/consume them from the [Common Azure Resource Modules Library repo](https://github.com/Azure/ResourceModules) when features like the Bicep Public Module Registry exists.
+
+> These are only plans/aspirations at this stage, but we are sharing with you for clarity 👍
+
+These modules are consumed and called by other modules within this repo. For example, the `customerUsageAttribution` module is called in all modules as you can see from each of those modules `.bicep` files.

--- a/BrownField/Addons/HCX/ARM/HCX.deploy.json
+++ b/BrownField/Addons/HCX/ARM/HCX.deploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1272.37030",
-      "templateHash": "16925160143016701712"
+      "templateHash": "4939662003978325105"
     }
   },
   "parameters": {
@@ -17,7 +17,7 @@
     }
   },
   "variables": {
-    "varCuaid": "754599a0-0a6f-424a-b4c5-1b12be198ae8"
+    "varCuaid": "ccdff80c-722d-42b7-8bd2-66aba33cba02"
   },
   "resources": [
     {

--- a/BrownField/Addons/HCX/ARM/HCX.deploy.json
+++ b/BrownField/Addons/HCX/ARM/HCX.deploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1124.51302",
-      "templateHash": "12205194956177575224"
+      "version": "0.4.1272.37030",
+      "templateHash": "16925160143016701712"
     }
   },
   "parameters": {
@@ -16,6 +16,9 @@
       }
     }
   },
+  "variables": {
+    "varCuaid": "754599a0-0a6f-424a-b4c5-1b12be198ae8"
+  },
   "resources": [
     {
       "type": "Microsoft.AVS/privateClouds/addons",
@@ -24,6 +27,30 @@
       "properties": {
         "addonType": "HCX",
         "offer": "VMware MaaS Cloud Provider"
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "[format('pid-{0}-{1}', variables('varCuaid'), uniqueString(resourceGroup().location))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {},
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.4.1272.37030",
+              "templateHash": "4174488789265615178"
+            }
+          },
+          "resources": []
+        }
       }
     }
   ]

--- a/BrownField/Addons/HCX/Bicep/HCX.bicep
+++ b/BrownField/Addons/HCX/Bicep/HCX.bicep
@@ -6,6 +6,9 @@ resource PrivateCloud 'Microsoft.AVS/privateClouds@2021-06-01' existing = {
   name: PrivateCloudName
 }
 
+// Customer Usage Attribution Id
+var varCuaid = '754599a0-0a6f-424a-b4c5-1b12be198ae8'
+
 // Set up HCX
 resource HCX 'Microsoft.AVS/privateClouds/addons@2021-06-01' = {
   name: 'hcx'
@@ -15,4 +18,11 @@ resource HCX 'Microsoft.AVS/privateClouds/addons@2021-06-01' = {
     // At the moment only HCX Advanced can be programatically deployed
     offer: 'VMware MaaS Cloud Provider'
   }
+}
+
+// Optional Deployment for Customer Usage Attribution
+module modCustomerUsageAttribution '../../../../BrownField/Addons/CUAID/customerUsageAttribution/cuaIdResourceGroup.bicep' = {
+  #disable-next-line no-loc-expr-outside-params
+  name: 'pid-${varCuaid}-${uniqueString(resourceGroup().location)}'
+  params: {}
 }

--- a/BrownField/Addons/HCX/Bicep/HCX.bicep
+++ b/BrownField/Addons/HCX/Bicep/HCX.bicep
@@ -7,7 +7,7 @@ resource PrivateCloud 'Microsoft.AVS/privateClouds@2021-06-01' existing = {
 }
 
 // Customer Usage Attribution Id
-var varCuaid = '754599a0-0a6f-424a-b4c5-1b12be198ae8'
+var varCuaid = 'ccdff80c-722d-42b7-8bd2-66aba33cba02'
 
 // Set up HCX
 resource HCX 'Microsoft.AVS/privateClouds/addons@2021-06-01' = {

--- a/BrownField/Addons/SRM/ARM/SRM.deploy.json
+++ b/BrownField/Addons/SRM/ARM/SRM.deploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1124.51302",
-      "templateHash": "6044808303230134209"
+      "version": "0.4.1272.37030",
+      "templateHash": "8461200527182985271"
     }
   },
   "parameters": {
@@ -31,6 +31,9 @@
       }
     }
   },
+  "variables": {
+    "varCuaid": "754599a0-0a6f-424a-b4c5-1b12be198ae8"
+  },
   "resources": [
     {
       "type": "Microsoft.AVS/privateClouds/addons",
@@ -52,6 +55,30 @@
       "dependsOn": [
         "[resourceId('Microsoft.AVS/privateClouds/addons', parameters('PrivateCloudName'), 'srm')]"
       ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "[format('pid-{0}-{1}', variables('varCuaid'), uniqueString(resourceGroup().location))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {},
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.4.1272.37030",
+              "templateHash": "4174488789265615178"
+            }
+          },
+          "resources": []
+        }
+      }
     }
   ]
 }

--- a/BrownField/Addons/SRM/ARM/SRM.deploy.json
+++ b/BrownField/Addons/SRM/ARM/SRM.deploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1272.37030",
-      "templateHash": "8461200527182985271"
+      "templateHash": "142440890599000820"
     }
   },
   "parameters": {
@@ -32,7 +32,7 @@
     }
   },
   "variables": {
-    "varCuaid": "754599a0-0a6f-424a-b4c5-1b12be198ae8"
+    "varCuaid": "c542e61c-1907-483f-9e18-76f5b85eee0a"
   },
   "resources": [
     {

--- a/BrownField/Addons/SRM/Bicep/SRM.bicep
+++ b/BrownField/Addons/SRM/Bicep/SRM.bicep
@@ -8,6 +8,9 @@ param SRMLicenseKey string = ''
 @minValue(1)
 param ReplicationServerCount int = 1
 
+// Customer Usage Attribution Id
+var varCuaid = '754599a0-0a6f-424a-b4c5-1b12be198ae8'
+
 // Get a reference to the existing private cloud
 resource PrivateCloud 'Microsoft.AVS/privateClouds@2021-06-01' existing = {
   name: PrivateCloudName
@@ -37,3 +40,9 @@ resource VR 'Microsoft.AVS/privateClouds/addons@2021-06-01' = {
   ]
 }
 
+// Optional Deployment for Customer Usage Attribution
+module modCustomerUsageAttribution '../../../../BrownField/Addons/CUAID/customerUsageAttribution/cuaIdResourceGroup.bicep' = {
+  #disable-next-line no-loc-expr-outside-params
+  name: 'pid-${varCuaid}-${uniqueString(resourceGroup().location)}'
+  params: {}
+}

--- a/BrownField/Addons/SRM/Bicep/SRM.bicep
+++ b/BrownField/Addons/SRM/Bicep/SRM.bicep
@@ -9,7 +9,7 @@ param SRMLicenseKey string = ''
 param ReplicationServerCount int = 1
 
 // Customer Usage Attribution Id
-var varCuaid = '754599a0-0a6f-424a-b4c5-1b12be198ae8'
+var varCuaid = 'c542e61c-1907-483f-9e18-76f5b85eee0a'
 
 // Get a reference to the existing private cloud
 resource PrivateCloud 'Microsoft.AVS/privateClouds@2021-06-01' existing = {

--- a/BrownField/Monitoring/AVS-Dashboard/ARM/AVSDashboard.deploy.json
+++ b/BrownField/Monitoring/AVS-Dashboard/ARM/AVSDashboard.deploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1124.51302",
-      "templateHash": "3918543573573887351"
+      "version": "0.4.1272.37030",
+      "templateHash": "8467838706235197401"
     }
   },
   "parameters": {
@@ -40,6 +40,7 @@
     }
   },
   "variables": {
+    "varCuaid": "754599a0-0a6f-424a-b4c5-1b12be198ae8",
     "DashboardHeading": {
       "position": {
         "colSpan": 6,
@@ -357,6 +358,30 @@
       },
       "tags": {
         "hidden-title": "[parameters('DashboardName')]"
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "[format('pid-{0}-{1}', variables('varCuaid'), uniqueString(resourceGroup().location))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {},
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.4.1272.37030",
+              "templateHash": "4174488789265615178"
+            }
+          },
+          "resources": []
+        }
       }
     }
   ]

--- a/BrownField/Monitoring/AVS-Dashboard/ARM/AVSDashboard.deploy.json
+++ b/BrownField/Monitoring/AVS-Dashboard/ARM/AVSDashboard.deploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1272.37030",
-      "templateHash": "8467838706235197401"
+      "templateHash": "3078573540625338306"
     }
   },
   "parameters": {
@@ -40,7 +40,7 @@
     }
   },
   "variables": {
-    "varCuaid": "754599a0-0a6f-424a-b4c5-1b12be198ae8",
+    "varCuaid": "6a449623-a5df-43f6-8df0-9b32dc2df958",
     "DashboardHeading": {
       "position": {
         "colSpan": 6,

--- a/BrownField/Monitoring/AVS-Dashboard/Bicep/AVSDashboard.bicep
+++ b/BrownField/Monitoring/AVS-Dashboard/Bicep/AVSDashboard.bicep
@@ -13,7 +13,7 @@ param PrivateCloudResourceId string
 param ExRConnectionResourceId string = ''
 
 // Customer Usage Attribution Id
-var varCuaid = '754599a0-0a6f-424a-b4c5-1b12be198ae8'
+var varCuaid = '6a449623-a5df-43f6-8df0-9b32dc2df958'
 
 var DashboardHeading = {
   position: {

--- a/BrownField/Monitoring/AVS-Dashboard/Bicep/AVSDashboard.bicep
+++ b/BrownField/Monitoring/AVS-Dashboard/Bicep/AVSDashboard.bicep
@@ -12,6 +12,8 @@ param PrivateCloudResourceId string
 @description('Optional, The full resource ID of the Express Route Connection used by AVS that you want displayed on this dashboard. Can be left empty to remove this metric')
 param ExRConnectionResourceId string = ''
 
+// Customer Usage Attribution Id
+var varCuaid = '754599a0-0a6f-424a-b4c5-1b12be198ae8'
 
 var DashboardHeading = {
   position: {
@@ -335,4 +337,11 @@ resource Dashboard 'Microsoft.Portal/dashboards@2019-01-01-preview' = {
   tags:{
     'hidden-title': DashboardName
   }
+}
+
+// Optional Deployment for Customer Usage Attribution
+module modCustomerUsageAttribution '../../../../BrownField/Addons/CUAID/customerUsageAttribution/cuaIdResourceGroup.bicep' = {
+  #disable-next-line no-loc-expr-outside-params
+  name: 'pid-${varCuaid}-${uniqueString(resourceGroup().location)}'
+  params: {}
 }

--- a/BrownField/Monitoring/AVS-Service-Health/ARM/AVSServiceHealth.deploy.json
+++ b/BrownField/Monitoring/AVS-Service-Health/ARM/AVSServiceHealth.deploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1124.51302",
-      "templateHash": "11170766057734741285"
+      "version": "0.4.1272.37030",
+      "templateHash": "9327087210433092392"
     }
   },
   "parameters": {
@@ -24,6 +24,7 @@
     }
   },
   "variables": {
+    "varCuaid": "754599a0-0a6f-424a-b4c5-1b12be198ae8",
     "suffix": "[uniqueString(parameters('PrivateCloudResourceId'))]",
     "formattedEmails": "[if(empty(trim(parameters('ActionGroupEmails'))), createArray(), split(parameters('ActionGroupEmails'), ','))]"
   },
@@ -92,6 +93,30 @@
       "dependsOn": [
         "[resourceId('microsoft.insights/actionGroups', format('AVS-ServiceHealth-{0}', variables('suffix')))]"
       ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "[format('pid-{0}-{1}', variables('varCuaid'), uniqueString(resourceGroup().location))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {},
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.4.1272.37030",
+              "templateHash": "4174488789265615178"
+            }
+          },
+          "resources": []
+        }
+      }
     }
   ]
 }

--- a/BrownField/Monitoring/AVS-Service-Health/ARM/AVSServiceHealth.deploy.json
+++ b/BrownField/Monitoring/AVS-Service-Health/ARM/AVSServiceHealth.deploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1272.37030",
-      "templateHash": "9327087210433092392"
+      "templateHash": "5146761970804686202"
     }
   },
   "parameters": {
@@ -24,7 +24,7 @@
     }
   },
   "variables": {
-    "varCuaid": "754599a0-0a6f-424a-b4c5-1b12be198ae8",
+    "varCuaid": "a182f0f1-a209-42fd-aa05-e12bda423653",
     "suffix": "[uniqueString(parameters('PrivateCloudResourceId'))]",
     "formattedEmails": "[if(empty(trim(parameters('ActionGroupEmails'))), createArray(), split(parameters('ActionGroupEmails'), ','))]"
   },

--- a/BrownField/Monitoring/AVS-Service-Health/Bicep/AVSServiceHealth.bicep
+++ b/BrownField/Monitoring/AVS-Service-Health/Bicep/AVSServiceHealth.bicep
@@ -5,7 +5,7 @@ param ActionGroupEmails string = ''
 param PrivateCloudResourceId string
 
 // Customer Usage Attribution Id
-var varCuaid = '754599a0-0a6f-424a-b4c5-1b12be198ae8'
+var varCuaid = 'a182f0f1-a209-42fd-aa05-e12bda423653'
 
 var suffix = uniqueString(PrivateCloudResourceId)
 

--- a/BrownField/Monitoring/AVS-Service-Health/Bicep/AVSServiceHealth.bicep
+++ b/BrownField/Monitoring/AVS-Service-Health/Bicep/AVSServiceHealth.bicep
@@ -4,6 +4,9 @@ param ActionGroupEmails string = ''
 @description('The existing Private Cloud full resource id')
 param PrivateCloudResourceId string
 
+// Customer Usage Attribution Id
+var varCuaid = '754599a0-0a6f-424a-b4c5-1b12be198ae8'
+
 var suffix = uniqueString(PrivateCloudResourceId)
 
 var formattedEmails = empty(trim(ActionGroupEmails)) ? [] : split(ActionGroupEmails, ',')
@@ -62,4 +65,11 @@ resource ServiceHealthAlert 'Microsoft.Insights/activityLogAlerts@2020-10-01' = 
       ]
     }
   }
+}
+
+// Optional Deployment for Customer Usage Attribution
+module modCustomerUsageAttribution '../../../../BrownField/Addons/CUAID/customerUsageAttribution/cuaIdResourceGroup.bicep' = {
+  #disable-next-line no-loc-expr-outside-params
+  name: 'pid-${varCuaid}-${uniqueString(resourceGroup().location)}'
+  params: {}
 }

--- a/BrownField/Monitoring/AVS-Utilization-Alerts/ARM/AVSMonitor.deploy.json
+++ b/BrownField/Monitoring/AVS-Utilization-Alerts/ARM/AVSMonitor.deploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1124.51302",
-      "templateHash": "4513908968230404416"
+      "version": "0.4.1272.37030",
+      "templateHash": "722154809642278983"
     }
   },
   "parameters": {
@@ -38,6 +38,7 @@
     }
   },
   "variables": {
+    "varCuaid": "754599a0-0a6f-424a-b4c5-1b12be198ae8",
     "Alerts": [
       {
         "Name": "CPU",
@@ -189,6 +190,30 @@
       "dependsOn": [
         "[resourceId('microsoft.insights/actionGroups', parameters('ActionGroupName'))]"
       ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "[format('pid-{0}-{1}', variables('varCuaid'), uniqueString(resourceGroup().location))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {},
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.4.1272.37030",
+              "templateHash": "4174488789265615178"
+            }
+          },
+          "resources": []
+        }
+      }
     }
   ]
 }

--- a/BrownField/Monitoring/AVS-Utilization-Alerts/ARM/AVSMonitor.deploy.json
+++ b/BrownField/Monitoring/AVS-Utilization-Alerts/ARM/AVSMonitor.deploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1272.37030",
-      "templateHash": "722154809642278983"
+      "templateHash": "5598468798837012617"
     }
   },
   "parameters": {
@@ -38,7 +38,7 @@
     }
   },
   "variables": {
-    "varCuaid": "754599a0-0a6f-424a-b4c5-1b12be198ae8",
+    "varCuaid": "6f7b68e9-1179-4853-9dfe-1a4f793b9893",
     "Alerts": [
       {
         "Name": "CPU",

--- a/BrownField/Monitoring/AVS-Utilization-Alerts/Bicep/AVSMonitor.bicep
+++ b/BrownField/Monitoring/AVS-Utilization-Alerts/Bicep/AVSMonitor.bicep
@@ -10,6 +10,9 @@ param ActionGroupEmails array = []
 @description('The existing Private Cloud full resource id')
 param PrivateCloudResourceId string
 
+// Customer Usage Attribution Id
+var varCuaid = '754599a0-0a6f-424a-b4c5-1b12be198ae8'
+
 // Create an action group to be used by the alerts
 resource ActionGroup 'microsoft.insights/actionGroups@2019-06-01' = {
   name: ActionGroupName
@@ -145,3 +148,10 @@ resource MetricAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = [for Alert i
     ]
   }
 }]
+
+// Optional Deployment for Customer Usage Attribution
+module modCustomerUsageAttribution '../../../../BrownField/Addons/CUAID/customerUsageAttribution/cuaIdResourceGroup.bicep' = {
+  #disable-next-line no-loc-expr-outside-params
+  name: 'pid-${varCuaid}-${uniqueString(resourceGroup().location)}'
+  params: {}
+}

--- a/BrownField/Monitoring/AVS-Utilization-Alerts/Bicep/AVSMonitor.bicep
+++ b/BrownField/Monitoring/AVS-Utilization-Alerts/Bicep/AVSMonitor.bicep
@@ -11,7 +11,7 @@ param ActionGroupEmails array = []
 param PrivateCloudResourceId string
 
 // Customer Usage Attribution Id
-var varCuaid = '754599a0-0a6f-424a-b4c5-1b12be198ae8'
+var varCuaid = '6f7b68e9-1179-4853-9dfe-1a4f793b9893'
 
 // Create an action group to be used by the alerts
 resource ActionGroup 'microsoft.insights/actionGroups@2019-06-01' = {

--- a/BrownField/Networking/AVS-to-AVS-CrossRegion-GlobalReach/ARM/CrossAVSGlobalReach.deploy.json
+++ b/BrownField/Networking/AVS-to-AVS-CrossRegion-GlobalReach/ARM/CrossAVSGlobalReach.deploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1272.37030",
-      "templateHash": "6544054942561053291"
+      "templateHash": "5388761589278936028"
     }
   },
   "parameters": {
@@ -60,7 +60,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1272.37030",
-              "templateHash": "15203017835508608515"
+              "templateHash": "2956281795248563008"
             }
           },
           "parameters": {
@@ -78,7 +78,7 @@
             }
           },
           "variables": {
-            "varCuaid": "754599a0-0a6f-424a-b4c5-1b12be198ae8"
+            "varCuaid": "1593acc2-6932-462b-af58-28f7fa9df52d"
           },
           "resources": [
             {
@@ -152,7 +152,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1272.37030",
-              "templateHash": "11933384025774505364"
+              "templateHash": "8814019771066365787"
             }
           },
           "parameters": {
@@ -176,7 +176,7 @@
             }
           },
           "variables": {
-            "varCuaid": "754599a0-0a6f-424a-b4c5-1b12be198ae8"
+            "varCuaid": "1593acc2-6932-462b-af58-28f7fa9df52d"
           },
           "resources": [
             {

--- a/BrownField/Networking/AVS-to-AVS-CrossRegion-GlobalReach/ARM/CrossAVSGlobalReach.deploy.json
+++ b/BrownField/Networking/AVS-to-AVS-CrossRegion-GlobalReach/ARM/CrossAVSGlobalReach.deploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1124.51302",
-      "templateHash": "7714480193584756616"
+      "version": "0.4.1272.37030",
+      "templateHash": "6544054942561053291"
     }
   },
   "parameters": {
@@ -59,8 +59,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1124.51302",
-              "templateHash": "812177194752214735"
+              "version": "0.4.1272.37030",
+              "templateHash": "15203017835508608515"
             }
           },
           "parameters": {
@@ -77,11 +77,38 @@
               }
             }
           },
+          "variables": {
+            "varCuaid": "754599a0-0a6f-424a-b4c5-1b12be198ae8"
+          },
           "resources": [
             {
               "type": "Microsoft.AVS/privateClouds/authorizations",
               "apiVersion": "2021-06-01",
               "name": "[format('{0}/{1}', parameters('PrivateCloudName'), parameters('AuthKeyName'))]"
+            },
+            {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2020-10-01",
+              "name": "[format('pid-{0}-{1}', variables('varCuaid'), uniqueString(resourceGroup().location))]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {},
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.4.1272.37030",
+                      "templateHash": "4174488789265615178"
+                    }
+                  },
+                  "resources": []
+                }
+              }
             }
           ],
           "outputs": {
@@ -112,10 +139,10 @@
             "value": "[parameters('PrimaryPrivateCloudName')]"
           },
           "ExpressRouteId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('SecondaryPrivateCloudResourceGroup')), 'Microsoft.Resources/deployments', 'SecondaryAuthKey'), '2020-10-01').outputs.ExpressRouteId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('SecondaryPrivateCloudResourceGroup')), 'Microsoft.Resources/deployments', 'SecondaryAuthKey')).outputs.ExpressRouteId.value]"
           },
           "ExpressRouteAuthorizationKey": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('SecondaryPrivateCloudResourceGroup')), 'Microsoft.Resources/deployments', 'SecondaryAuthKey'), '2020-10-01').outputs.ExpressRouteAuthorizationKey.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('SecondaryPrivateCloudResourceGroup')), 'Microsoft.Resources/deployments', 'SecondaryAuthKey')).outputs.ExpressRouteAuthorizationKey.value]"
           }
         },
         "template": {
@@ -124,8 +151,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1124.51302",
-              "templateHash": "16188408207026649776"
+              "version": "0.4.1272.37030",
+              "templateHash": "11933384025774505364"
             }
           },
           "parameters": {
@@ -148,6 +175,9 @@
               }
             }
           },
+          "variables": {
+            "varCuaid": "754599a0-0a6f-424a-b4c5-1b12be198ae8"
+          },
           "resources": [
             {
               "type": "Microsoft.AVS/privateClouds/globalReachConnections",
@@ -156,6 +186,30 @@
               "properties": {
                 "authorizationKey": "[parameters('ExpressRouteAuthorizationKey')]",
                 "peerExpressRouteCircuit": "[parameters('ExpressRouteId')]"
+              }
+            },
+            {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2020-10-01",
+              "name": "[format('pid-{0}-{1}', variables('varCuaid'), uniqueString(resourceGroup().location))]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {},
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.4.1272.37030",
+                      "templateHash": "4174488789265615178"
+                    }
+                  },
+                  "resources": []
+                }
               }
             }
           ]

--- a/BrownField/Networking/AVS-to-AVS-CrossRegion-GlobalReach/Bicep/Modules/AVSAuthorization.bicep
+++ b/BrownField/Networking/AVS-to-AVS-CrossRegion-GlobalReach/Bicep/Modules/AVSAuthorization.bicep
@@ -4,6 +4,9 @@ param PrivateCloudName string
 @description('The authorization key name to be created')
 param AuthKeyName string
 
+// Customer Usage Attribution Id
+var varCuaid = '754599a0-0a6f-424a-b4c5-1b12be198ae8'
+
 // Get a reference to the existing private cloud
 resource PrivateCloud 'Microsoft.AVS/privateClouds@2021-06-01' existing = {
   name: PrivateCloudName
@@ -18,3 +21,10 @@ resource ExpressRouteAuthKey 'Microsoft.AVS/privateClouds/authorizations@2021-06
 // Return the Express Route ID and the new Authorization Key
 output ExpressRouteAuthorizationKey string = ExpressRouteAuthKey.properties.expressRouteAuthorizationKey
 output ExpressRouteId string = PrivateCloud.properties.circuit.expressRouteID
+
+// Optional Deployment for Customer Usage Attribution
+module modCustomerUsageAttribution '../../../../../BrownField/Addons/CUAID/customerUsageAttribution/cuaIdResourceGroup.bicep' = {
+  #disable-next-line no-loc-expr-outside-params
+  name: 'pid-${varCuaid}-${uniqueString(resourceGroup().location)}'
+  params: {}
+}

--- a/BrownField/Networking/AVS-to-AVS-CrossRegion-GlobalReach/Bicep/Modules/AVSAuthorization.bicep
+++ b/BrownField/Networking/AVS-to-AVS-CrossRegion-GlobalReach/Bicep/Modules/AVSAuthorization.bicep
@@ -5,7 +5,7 @@ param PrivateCloudName string
 param AuthKeyName string
 
 // Customer Usage Attribution Id
-var varCuaid = '754599a0-0a6f-424a-b4c5-1b12be198ae8'
+var varCuaid = '1593acc2-6932-462b-af58-28f7fa9df52d'
 
 // Get a reference to the existing private cloud
 resource PrivateCloud 'Microsoft.AVS/privateClouds@2021-06-01' existing = {

--- a/BrownField/Networking/AVS-to-AVS-CrossRegion-GlobalReach/Bicep/Modules/GlobalReach.bicep
+++ b/BrownField/Networking/AVS-to-AVS-CrossRegion-GlobalReach/Bicep/Modules/GlobalReach.bicep
@@ -9,6 +9,9 @@ param ExpressRouteAuthorizationKey string
 @secure()
 param ExpressRouteId string
 
+// Customer Usage Attribution Id
+var varCuaid = '754599a0-0a6f-424a-b4c5-1b12be198ae8'
+
 // Get a reference to the existing private cloud
 resource PrivateCloud 'Microsoft.AVS/privateClouds@2021-06-01' existing = {
   name: PrivateCloudName
@@ -22,4 +25,11 @@ resource GlobalReach 'Microsoft.AVS/privateClouds/globalReachConnections@2021-06
     authorizationKey: ExpressRouteAuthorizationKey
     peerExpressRouteCircuit: ExpressRouteId
   }
+}
+
+// Optional Deployment for Customer Usage Attribution
+module modCustomerUsageAttribution '../../../../../BrownField/Addons/CUAID/customerUsageAttribution/cuaIdResourceGroup.bicep' = {
+  #disable-next-line no-loc-expr-outside-params
+  name: 'pid-${varCuaid}-${uniqueString(resourceGroup().location)}'
+  params: {}
 }

--- a/BrownField/Networking/AVS-to-AVS-CrossRegion-GlobalReach/Bicep/Modules/GlobalReach.bicep
+++ b/BrownField/Networking/AVS-to-AVS-CrossRegion-GlobalReach/Bicep/Modules/GlobalReach.bicep
@@ -10,7 +10,7 @@ param ExpressRouteAuthorizationKey string
 param ExpressRouteId string
 
 // Customer Usage Attribution Id
-var varCuaid = '754599a0-0a6f-424a-b4c5-1b12be198ae8'
+var varCuaid = '1593acc2-6932-462b-af58-28f7fa9df52d'
 
 // Get a reference to the existing private cloud
 resource PrivateCloud 'Microsoft.AVS/privateClouds@2021-06-01' existing = {

--- a/BrownField/Networking/AVS-to-AVS-SameRegion/ARM/CrossAVSWithinRegion.deploy.json
+++ b/BrownField/Networking/AVS-to-AVS-SameRegion/ARM/CrossAVSWithinRegion.deploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1124.51302",
-      "templateHash": "11263655147757911901"
+      "version": "0.4.1272.37030",
+      "templateHash": "5993211812823445439"
     }
   },
   "parameters": {
@@ -22,6 +22,9 @@
       }
     }
   },
+  "variables": {
+    "varCuaid": "754599a0-0a6f-424a-b4c5-1b12be198ae8"
+  },
   "resources": [
     {
       "type": "Microsoft.AVS/privateClouds/cloudLinks",
@@ -29,6 +32,30 @@
       "name": "[format('{0}/{1}', parameters('PrimaryPrivateCloudName'), guid(parameters('SecondaryPrivateCloudId')))]",
       "properties": {
         "linkedCloud": "[parameters('SecondaryPrivateCloudId')]"
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "[format('pid-{0}-{1}', variables('varCuaid'), uniqueString(resourceGroup().location))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {},
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.4.1272.37030",
+              "templateHash": "4174488789265615178"
+            }
+          },
+          "resources": []
+        }
       }
     }
   ]

--- a/BrownField/Networking/AVS-to-AVS-SameRegion/ARM/CrossAVSWithinRegion.deploy.json
+++ b/BrownField/Networking/AVS-to-AVS-SameRegion/ARM/CrossAVSWithinRegion.deploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1272.37030",
-      "templateHash": "5993211812823445439"
+      "templateHash": "17389485434702717954"
     }
   },
   "parameters": {
@@ -23,7 +23,7 @@
     }
   },
   "variables": {
-    "varCuaid": "754599a0-0a6f-424a-b4c5-1b12be198ae8"
+    "varCuaid": "08d3edb1-3d70-4c0f-ab9f-f491b4a8d737"
   },
   "resources": [
     {

--- a/BrownField/Networking/AVS-to-AVS-SameRegion/Bicep/CrossAVSWithinRegion.bicep
+++ b/BrownField/Networking/AVS-to-AVS-SameRegion/Bicep/CrossAVSWithinRegion.bicep
@@ -4,6 +4,9 @@ param PrimaryPrivateCloudName string
 @description('Full resource id of the secondary private cloud, must be in the same region as the primary')
 param SecondaryPrivateCloudId string
 
+// Customer Usage Attribution Id
+var varCuaid = '754599a0-0a6f-424a-b4c5-1b12be198ae8'
+
 // Get a reference to the existing private cloud
 resource PrivateCloud 'Microsoft.AVS/privateClouds@2021-06-01' existing = {
   name: PrimaryPrivateCloudName
@@ -16,4 +19,11 @@ resource PrivateCloudLink 'Microsoft.AVS/privateClouds/cloudLinks@2021-06-01' = 
   properties: {
     linkedCloud: SecondaryPrivateCloudId
   }
+}
+
+// Optional Deployment for Customer Usage Attribution
+module modCustomerUsageAttribution '../../../../BrownField/Addons/CUAID/customerUsageAttribution/cuaIdResourceGroup.bicep' = {
+  #disable-next-line no-loc-expr-outside-params
+  name: 'pid-${varCuaid}-${uniqueString(resourceGroup().location)}'
+  params: {}
 }

--- a/BrownField/Networking/AVS-to-AVS-SameRegion/Bicep/CrossAVSWithinRegion.bicep
+++ b/BrownField/Networking/AVS-to-AVS-SameRegion/Bicep/CrossAVSWithinRegion.bicep
@@ -5,7 +5,7 @@ param PrimaryPrivateCloudName string
 param SecondaryPrivateCloudId string
 
 // Customer Usage Attribution Id
-var varCuaid = '754599a0-0a6f-424a-b4c5-1b12be198ae8'
+var varCuaid = '08d3edb1-3d70-4c0f-ab9f-f491b4a8d737'
 
 // Get a reference to the existing private cloud
 resource PrivateCloud 'Microsoft.AVS/privateClouds@2021-06-01' existing = {

--- a/BrownField/Networking/AVS-to-OnPremises-ExpressRoute-GlobalReach/ARM/AVSGlobalReach.deploy.json
+++ b/BrownField/Networking/AVS-to-OnPremises-ExpressRoute-GlobalReach/ARM/AVSGlobalReach.deploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1272.37030",
-      "templateHash": "11933384025774505364"
+      "templateHash": "16882334144361166307"
     }
   },
   "parameters": {
@@ -29,7 +29,7 @@
     }
   },
   "variables": {
-    "varCuaid": "754599a0-0a6f-424a-b4c5-1b12be198ae8"
+    "varCuaid": "8fb78b9c-973d-45d1-bd35-fcad3c00e09e"
   },
   "resources": [
     {

--- a/BrownField/Networking/AVS-to-OnPremises-ExpressRoute-GlobalReach/ARM/AVSGlobalReach.deploy.json
+++ b/BrownField/Networking/AVS-to-OnPremises-ExpressRoute-GlobalReach/ARM/AVSGlobalReach.deploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1124.51302",
-      "templateHash": "16188408207026649776"
+      "version": "0.4.1272.37030",
+      "templateHash": "11933384025774505364"
     }
   },
   "parameters": {
@@ -28,6 +28,9 @@
       }
     }
   },
+  "variables": {
+    "varCuaid": "754599a0-0a6f-424a-b4c5-1b12be198ae8"
+  },
   "resources": [
     {
       "type": "Microsoft.AVS/privateClouds/globalReachConnections",
@@ -36,6 +39,30 @@
       "properties": {
         "authorizationKey": "[parameters('ExpressRouteAuthorizationKey')]",
         "peerExpressRouteCircuit": "[parameters('ExpressRouteId')]"
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "[format('pid-{0}-{1}', variables('varCuaid'), uniqueString(resourceGroup().location))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {},
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.4.1272.37030",
+              "templateHash": "4174488789265615178"
+            }
+          },
+          "resources": []
+        }
       }
     }
   ]

--- a/BrownField/Networking/AVS-to-OnPremises-ExpressRoute-GlobalReach/Bicep/AVSGlobalReach.bicep
+++ b/BrownField/Networking/AVS-to-OnPremises-ExpressRoute-GlobalReach/Bicep/AVSGlobalReach.bicep
@@ -9,6 +9,9 @@ param ExpressRouteAuthorizationKey string
 @secure()
 param ExpressRouteId string
 
+// Customer Usage Attribution Id
+var varCuaid = '754599a0-0a6f-424a-b4c5-1b12be198ae8'
+
 // Get a reference to the existing private cloud
 resource PrivateCloud 'Microsoft.AVS/privateClouds@2021-06-01' existing = {
   name: PrivateCloudName
@@ -22,4 +25,11 @@ resource GlobalReach 'Microsoft.AVS/privateClouds/globalReachConnections@2021-06
     authorizationKey: ExpressRouteAuthorizationKey
     peerExpressRouteCircuit: ExpressRouteId
   }
+}
+
+// Optional Deployment for Customer Usage Attribution
+module modCustomerUsageAttribution '../../../../BrownField/Addons/CUAID/customerUsageAttribution/cuaIdResourceGroup.bicep' = {
+  #disable-next-line no-loc-expr-outside-params
+  name: 'pid-${varCuaid}-${uniqueString(resourceGroup().location)}'
+  params: {}
 }

--- a/BrownField/Networking/AVS-to-OnPremises-ExpressRoute-GlobalReach/Bicep/AVSGlobalReach.bicep
+++ b/BrownField/Networking/AVS-to-OnPremises-ExpressRoute-GlobalReach/Bicep/AVSGlobalReach.bicep
@@ -10,7 +10,7 @@ param ExpressRouteAuthorizationKey string
 param ExpressRouteId string
 
 // Customer Usage Attribution Id
-var varCuaid = '754599a0-0a6f-424a-b4c5-1b12be198ae8'
+var varCuaid = '8fb78b9c-973d-45d1-bd35-fcad3c00e09e'
 
 // Get a reference to the existing private cloud
 resource PrivateCloud 'Microsoft.AVS/privateClouds@2021-06-01' existing = {

--- a/BrownField/Networking/AVS-to-VNet-ExistingVNet/ARM/ExRConnection.deploy.json
+++ b/BrownField/Networking/AVS-to-VNet-ExistingVNet/ARM/ExRConnection.deploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1124.51302",
-      "templateHash": "14370328315967702824"
+      "version": "0.4.1272.37030",
+      "templateHash": "15160302690210466127"
     }
   },
   "parameters": {
@@ -43,6 +43,9 @@
       }
     }
   },
+  "variables": {
+    "varCuaid": "754599a0-0a6f-424a-b4c5-1b12be198ae8"
+  },
   "resources": [
     {
       "type": "Microsoft.Network/connections",
@@ -57,9 +60,9 @@
           "properties": {}
         },
         "peer": {
-          "id": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('PrivateCloudSubscriptionId'), parameters('PrivateCloudResourceGroup')), 'Microsoft.Resources/deployments', 'AVSAuthorization'), '2020-10-01').outputs.ExpressRouteId.value]"
+          "id": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('PrivateCloudSubscriptionId'), parameters('PrivateCloudResourceGroup')), 'Microsoft.Resources/deployments', 'AVSAuthorization')).outputs.ExpressRouteId.value]"
         },
-        "authorizationKey": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('PrivateCloudSubscriptionId'), parameters('PrivateCloudResourceGroup')), 'Microsoft.Resources/deployments', 'AVSAuthorization'), '2020-10-01').outputs.ExpressRouteAuthorizationKey.value]"
+        "authorizationKey": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('PrivateCloudSubscriptionId'), parameters('PrivateCloudResourceGroup')), 'Microsoft.Resources/deployments', 'AVSAuthorization')).outputs.ExpressRouteAuthorizationKey.value]"
       },
       "dependsOn": [
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('PrivateCloudSubscriptionId'), parameters('PrivateCloudResourceGroup')), 'Microsoft.Resources/deployments', 'AVSAuthorization')]"
@@ -90,8 +93,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1124.51302",
-              "templateHash": "812177194752214735"
+              "version": "0.4.1272.37030",
+              "templateHash": "4533823652273022810"
             }
           },
           "parameters": {
@@ -125,6 +128,30 @@
               "value": "[reference(resourceId('Microsoft.AVS/privateClouds', parameters('PrivateCloudName')), '2021-06-01').circuit.expressRouteID]"
             }
           }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "[format('pid-{0}-{1}', variables('varCuaid'), uniqueString(resourceGroup().location))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {},
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.4.1272.37030",
+              "templateHash": "4174488789265615178"
+            }
+          },
+          "resources": []
         }
       }
     }

--- a/BrownField/Networking/AVS-to-VNet-ExistingVNet/ARM/ExRConnection.deploy.json
+++ b/BrownField/Networking/AVS-to-VNet-ExistingVNet/ARM/ExRConnection.deploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1272.37030",
-      "templateHash": "15160302690210466127"
+      "templateHash": "13416436112607048732"
     }
   },
   "parameters": {
@@ -44,7 +44,7 @@
     }
   },
   "variables": {
-    "varCuaid": "754599a0-0a6f-424a-b4c5-1b12be198ae8"
+    "varCuaid": "9dd111b1-82f0-4104-bcf9-18b777f0c78f"
   },
   "resources": [
     {

--- a/BrownField/Networking/AVS-to-VNet-ExistingVNet/Bicep/ExRConnection.bicep
+++ b/BrownField/Networking/AVS-to-VNet-ExistingVNet/Bicep/ExRConnection.bicep
@@ -14,6 +14,9 @@ param GatewayName string
 @description('The location of the virtual network gateway')
 param Location string = resourceGroup().location
 
+// Customer Usage Attribution Id
+var varCuaid = '754599a0-0a6f-424a-b4c5-1b12be198ae8'
+
 // Create an AVS ExR Autorization Key via a module
 module AVSAuthorization 'Modules/AVSAuthorization.bicep' = {
   name: 'AVSAuthorization'
@@ -45,4 +48,11 @@ resource Connection 'Microsoft.Network/connections@2021-02-01' = {
     }
     authorizationKey: AVSAuthorization.outputs.ExpressRouteAuthorizationKey
   }
+}
+
+// Optional Deployment for Customer Usage Attribution
+module modCustomerUsageAttribution '../../../../BrownField/Addons/CUAID/customerUsageAttribution/cuaIdResourceGroup.bicep' = {
+  #disable-next-line no-loc-expr-outside-params
+  name: 'pid-${varCuaid}-${uniqueString(resourceGroup().location)}'
+  params: {}
 }

--- a/BrownField/Networking/AVS-to-VNet-ExistingVNet/Bicep/ExRConnection.bicep
+++ b/BrownField/Networking/AVS-to-VNet-ExistingVNet/Bicep/ExRConnection.bicep
@@ -15,7 +15,7 @@ param GatewayName string
 param Location string = resourceGroup().location
 
 // Customer Usage Attribution Id
-var varCuaid = '754599a0-0a6f-424a-b4c5-1b12be198ae8'
+var varCuaid = '9dd111b1-82f0-4104-bcf9-18b777f0c78f'
 
 // Create an AVS ExR Autorization Key via a module
 module AVSAuthorization 'Modules/AVSAuthorization.bicep' = {

--- a/BrownField/Networking/AVS-to-VNet-NewVNet/ARM/VNetWithExR.deploy.json
+++ b/BrownField/Networking/AVS-to-VNet-NewVNet/ARM/VNetWithExR.deploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1272.37030",
-      "templateHash": "12136585714159565376"
+      "templateHash": "1828596135852320460"
     }
   },
   "parameters": {
@@ -78,7 +78,7 @@
     }
   },
   "variables": {
-    "varCuaid": "754599a0-0a6f-424a-b4c5-1b12be198ae8"
+    "varCuaid": "938cd838-e22a-47da-8a6f-bdda923e3edb"
   },
   "resources": [
     {

--- a/BrownField/Networking/AVS-to-VNet-NewVNet/ARM/VNetWithExR.deploy.json
+++ b/BrownField/Networking/AVS-to-VNet-NewVNet/ARM/VNetWithExR.deploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1124.51302",
-      "templateHash": "8541914669306761488"
+      "version": "0.4.1272.37030",
+      "templateHash": "12136585714159565376"
     }
   },
   "parameters": {
@@ -76,6 +76,9 @@
         "description": "Virtual network gateway SKU to be created"
       }
     }
+  },
+  "variables": {
+    "varCuaid": "754599a0-0a6f-424a-b4c5-1b12be198ae8"
   },
   "resources": [
     {
@@ -156,9 +159,9 @@
           "properties": {}
         },
         "peer": {
-          "id": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('PrivateCloudSubscriptionId'), parameters('PrivateCloudResourceGroup')), 'Microsoft.Resources/deployments', 'AVSAuthorization'), '2020-10-01').outputs.ExpressRouteId.value]"
+          "id": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('PrivateCloudSubscriptionId'), parameters('PrivateCloudResourceGroup')), 'Microsoft.Resources/deployments', 'AVSAuthorization')).outputs.ExpressRouteId.value]"
         },
-        "authorizationKey": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('PrivateCloudSubscriptionId'), parameters('PrivateCloudResourceGroup')), 'Microsoft.Resources/deployments', 'AVSAuthorization'), '2020-10-01').outputs.ExpressRouteAuthorizationKey.value]"
+        "authorizationKey": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('PrivateCloudSubscriptionId'), parameters('PrivateCloudResourceGroup')), 'Microsoft.Resources/deployments', 'AVSAuthorization')).outputs.ExpressRouteAuthorizationKey.value]"
       },
       "dependsOn": [
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('PrivateCloudSubscriptionId'), parameters('PrivateCloudResourceGroup')), 'Microsoft.Resources/deployments', 'AVSAuthorization')]",
@@ -190,8 +193,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1124.51302",
-              "templateHash": "812177194752214735"
+              "version": "0.4.1272.37030",
+              "templateHash": "4533823652273022810"
             }
           },
           "parameters": {
@@ -225,6 +228,30 @@
               "value": "[reference(resourceId('Microsoft.AVS/privateClouds', parameters('PrivateCloudName')), '2021-06-01').circuit.expressRouteID]"
             }
           }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "[format('pid-{0}-{1}', variables('varCuaid'), uniqueString(resourceGroup().location))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {},
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.4.1272.37030",
+              "templateHash": "4174488789265615178"
+            }
+          },
+          "resources": []
         }
       }
     }

--- a/BrownField/Networking/AVS-to-VNet-NewVNet/Bicep/VNetWithExR.bicep
+++ b/BrownField/Networking/AVS-to-VNet-NewVNet/Bicep/VNetWithExR.bicep
@@ -24,7 +24,7 @@ param VNetGatewaySubnet string
 param GatewayName string = VNetName
 
 // Customer Usage Attribution Id
-var varCuaid = '754599a0-0a6f-424a-b4c5-1b12be198ae8'
+var varCuaid = '938cd838-e22a-47da-8a6f-bdda923e3edb'
 
 @description('Virtual network gateway SKU to be created')
 @allowed([

--- a/BrownField/Networking/AVS-to-VNet-NewVNet/Bicep/VNetWithExR.bicep
+++ b/BrownField/Networking/AVS-to-VNet-NewVNet/Bicep/VNetWithExR.bicep
@@ -23,6 +23,9 @@ param VNetGatewaySubnet string
 @description('Name of the virtual network gateway to be created')
 param GatewayName string = VNetName
 
+// Customer Usage Attribution Id
+var varCuaid = '754599a0-0a6f-424a-b4c5-1b12be198ae8'
+
 @description('Virtual network gateway SKU to be created')
 @allowed([
   'Standard'
@@ -121,4 +124,11 @@ resource Connection 'Microsoft.Network/connections@2021-02-01' = {
     }
     authorizationKey: AVSAuthorization.outputs.ExpressRouteAuthorizationKey
   }
+}
+
+// Optional Deployment for Customer Usage Attribution
+module modCustomerUsageAttribution '../../../../BrownField/Addons/CUAID/customerUsageAttribution/cuaIdResourceGroup.bicep' = {
+  #disable-next-line no-loc-expr-outside-params
+  name: 'pid-${varCuaid}-${uniqueString(resourceGroup().location)}'
+  params: {}
 }

--- a/BrownField/Networking/ExpressRoute-to-VNet/ARM/ExRConnection.deploy.json
+++ b/BrownField/Networking/ExpressRoute-to-VNet/ARM/ExRConnection.deploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1272.37030",
-      "templateHash": "9570007319509094920"
+      "templateHash": "3778111827064092710"
     }
   },
   "parameters": {
@@ -42,7 +42,7 @@
     }
   },
   "variables": {
-    "varCuaid": "754599a0-0a6f-424a-b4c5-1b12be198ae8"
+    "varCuaid": "174ca090-c796-4183-bc1f-ac6578e81d39"
   },
   "resources": [
     {

--- a/BrownField/Networking/ExpressRoute-to-VNet/ARM/ExRConnection.deploy.json
+++ b/BrownField/Networking/ExpressRoute-to-VNet/ARM/ExRConnection.deploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1124.51302",
-      "templateHash": "3323104891404111010"
+      "version": "0.4.1272.37030",
+      "templateHash": "9570007319509094920"
     }
   },
   "parameters": {
@@ -41,6 +41,9 @@
       }
     }
   },
+  "variables": {
+    "varCuaid": "754599a0-0a6f-424a-b4c5-1b12be198ae8"
+  },
   "resources": [
     {
       "type": "Microsoft.Network/connections",
@@ -58,6 +61,30 @@
           "id": "[parameters('ExpressRouteId')]"
         },
         "authorizationKey": "[parameters('ExpressRouteAuthorizationKey')]"
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "[format('pid-{0}-{1}', variables('varCuaid'), uniqueString(resourceGroup().location))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {},
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.4.1272.37030",
+              "templateHash": "4174488789265615178"
+            }
+          },
+          "resources": []
+        }
       }
     }
   ]

--- a/BrownField/Networking/ExpressRoute-to-VNet/Bicep/ExRConnection.bicep
+++ b/BrownField/Networking/ExpressRoute-to-VNet/Bicep/ExRConnection.bicep
@@ -17,7 +17,7 @@ param ExpressRouteAuthorizationKey string
 param ExpressRouteId string
 
 // Customer Usage Attribution Id
-var varCuaid = '754599a0-0a6f-424a-b4c5-1b12be198ae8'
+var varCuaid = '174ca090-c796-4183-bc1f-ac6578e81d39'
 
 // Get a reference to the existing virtual network gateway
 resource Gateway 'Microsoft.Network/virtualNetworkGateways@2021-02-01' existing = {

--- a/BrownField/Networking/ExpressRoute-to-VNet/Bicep/ExRConnection.bicep
+++ b/BrownField/Networking/ExpressRoute-to-VNet/Bicep/ExRConnection.bicep
@@ -16,6 +16,9 @@ param ExpressRouteAuthorizationKey string
 @secure()
 param ExpressRouteId string
 
+// Customer Usage Attribution Id
+var varCuaid = '754599a0-0a6f-424a-b4c5-1b12be198ae8'
+
 // Get a reference to the existing virtual network gateway
 resource Gateway 'Microsoft.Network/virtualNetworkGateways@2021-02-01' existing = {
   name: GatewayName
@@ -37,4 +40,11 @@ resource Connection 'Microsoft.Network/connections@2021-02-01' = {
     }
     authorizationKey: ExpressRouteAuthorizationKey
   }
+}
+
+// Optional Deployment for Customer Usage Attribution
+module modCustomerUsageAttribution '../../../../BrownField/Addons/CUAID/customerUsageAttribution/cuaIdResourceGroup.bicep' = {
+  #disable-next-line no-loc-expr-outside-params
+  name: 'pid-${varCuaid}-${uniqueString(resourceGroup().location)}'
+  params: {}
 }

--- a/BrownField/PrivateCloud/AVS-PrivateCloud-WithHCX/ARM/PrivateCloudWithHCX.deploy.json
+++ b/BrownField/PrivateCloud/AVS-PrivateCloud-WithHCX/ARM/PrivateCloudWithHCX.deploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1272.37030",
-      "templateHash": "14002344606787510080"
+      "templateHash": "104972711771768830"
     }
   },
   "parameters": {
@@ -44,7 +44,7 @@
     }
   },
   "variables": {
-    "varCuaid": "754599a0-0a6f-424a-b4c5-1b12be198ae8"
+    "varCuaid": "99f18c8b-1767-4302-9cee-ecc0d135dd52"
   },
   "resources": [
     {

--- a/BrownField/PrivateCloud/AVS-PrivateCloud-WithHCX/ARM/PrivateCloudWithHCX.deploy.json
+++ b/BrownField/PrivateCloud/AVS-PrivateCloud-WithHCX/ARM/PrivateCloudWithHCX.deploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1124.51302",
-      "templateHash": "11715639621467102323"
+      "version": "0.4.1272.37030",
+      "templateHash": "14002344606787510080"
     }
   },
   "parameters": {
@@ -42,6 +42,9 @@
         "description": "Opt-out of deployment telemetry"
       }
     }
+  },
+  "variables": {
+    "varCuaid": "754599a0-0a6f-424a-b4c5-1b12be198ae8"
   },
   "resources": [
     {
@@ -81,6 +84,30 @@
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
           "contentVersion": "1.0.0.0",
+          "resources": []
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "[format('pid-{0}-{1}', variables('varCuaid'), uniqueString(resourceGroup().location))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {},
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.4.1272.37030",
+              "templateHash": "4174488789265615178"
+            }
+          },
           "resources": []
         }
       }

--- a/BrownField/PrivateCloud/AVS-PrivateCloud-WithHCX/Bicep/PrivateCloudWithHCX.bicep
+++ b/BrownField/PrivateCloud/AVS-PrivateCloud-WithHCX/Bicep/PrivateCloudWithHCX.bicep
@@ -14,7 +14,7 @@ param Location string = resourceGroup().location
 param TelemetryOptOut bool = false
 
 // Customer Usage Attribution Id
-var varCuaid = '754599a0-0a6f-424a-b4c5-1b12be198ae8'
+var varCuaid = '99f18c8b-1767-4302-9cee-ecc0d135dd52'
 
 // Create the Private Cloud
 resource PrivateCloud 'Microsoft.AVS/privateClouds@2021-06-01' = {

--- a/BrownField/PrivateCloud/AVS-PrivateCloud-WithHCX/Bicep/PrivateCloudWithHCX.bicep
+++ b/BrownField/PrivateCloud/AVS-PrivateCloud-WithHCX/Bicep/PrivateCloudWithHCX.bicep
@@ -13,6 +13,9 @@ param Location string = resourceGroup().location
 @description('Opt-out of deployment telemetry')
 param TelemetryOptOut bool = false
 
+// Customer Usage Attribution Id
+var varCuaid = '754599a0-0a6f-424a-b4c5-1b12be198ae8'
+
 // Create the Private Cloud
 resource PrivateCloud 'Microsoft.AVS/privateClouds@2021-06-01' = {
   name: PrivateCloudName
@@ -48,4 +51,11 @@ resource Telemetry 'Microsoft.Resources/deployments@2021-04-01' = if (!Telemetry
       resources: []
     }
   }
+}
+
+// Optional Deployment for Customer Usage Attribution
+module modCustomerUsageAttribution '../../../../BrownField/Addons/CUAID/customerUsageAttribution/cuaIdResourceGroup.bicep' = {
+  #disable-next-line no-loc-expr-outside-params
+  name: 'pid-${varCuaid}-${uniqueString(resourceGroup().location)}'
+  params: {}
 }

--- a/BrownField/PrivateCloud/AVS-PrivateCloud/ARM/PrivateCloud.deploy.json
+++ b/BrownField/PrivateCloud/AVS-PrivateCloud/ARM/PrivateCloud.deploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1124.51302",
-      "templateHash": "4139974035602926957"
+      "version": "0.4.1272.37030",
+      "templateHash": "7258569812945282205"
     }
   },
   "parameters": {
@@ -43,6 +43,9 @@
       }
     }
   },
+  "variables": {
+    "varCuaid": "754599a0-0a6f-424a-b4c5-1b12be198ae8"
+  },
   "resources": [
     {
       "type": "Microsoft.AVS/privateClouds",
@@ -69,6 +72,30 @@
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
           "contentVersion": "1.0.0.0",
+          "resources": []
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "[format('pid-{0}-{1}', variables('varCuaid'), uniqueString(resourceGroup().location))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {},
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.4.1272.37030",
+              "templateHash": "4174488789265615178"
+            }
+          },
           "resources": []
         }
       }

--- a/BrownField/PrivateCloud/AVS-PrivateCloud/ARM/PrivateCloud.deploy.json
+++ b/BrownField/PrivateCloud/AVS-PrivateCloud/ARM/PrivateCloud.deploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1272.37030",
-      "templateHash": "7258569812945282205"
+      "templateHash": "3209659292921415579"
     }
   },
   "parameters": {
@@ -44,7 +44,7 @@
     }
   },
   "variables": {
-    "varCuaid": "754599a0-0a6f-424a-b4c5-1b12be198ae8"
+    "varCuaid": "fe003615-ca8e-412f-8091-43e1e42ebfd8"
   },
   "resources": [
     {

--- a/BrownField/PrivateCloud/AVS-PrivateCloud/Bicep/PrivateCloud.bicep
+++ b/BrownField/PrivateCloud/AVS-PrivateCloud/Bicep/PrivateCloud.bicep
@@ -14,7 +14,7 @@ param Location string = resourceGroup().location
 param TelemetryOptOut bool = false
 
 // Customer Usage Attribution Id
-var varCuaid = '754599a0-0a6f-424a-b4c5-1b12be198ae8'
+var varCuaid = 'fe003615-ca8e-412f-8091-43e1e42ebfd8'
 
 // AVS Private Cloud Resource
 resource PrivateCloud 'Microsoft.AVS/privateClouds@2021-06-01' = {

--- a/BrownField/PrivateCloud/AVS-PrivateCloud/Bicep/PrivateCloud.bicep
+++ b/BrownField/PrivateCloud/AVS-PrivateCloud/Bicep/PrivateCloud.bicep
@@ -13,6 +13,9 @@ param Location string = resourceGroup().location
 @description('Opt-out of deployment telemetry')
 param TelemetryOptOut bool = false
 
+// Customer Usage Attribution Id
+var varCuaid = '754599a0-0a6f-424a-b4c5-1b12be198ae8'
+
 // AVS Private Cloud Resource
 resource PrivateCloud 'Microsoft.AVS/privateClouds@2021-06-01' = {
   name: PrivateCloudName
@@ -38,4 +41,11 @@ resource Telemetry 'Microsoft.Resources/deployments@2021-04-01' = if (!Telemetry
       resources: []
     }
   }
+}
+
+// Optional Deployment for Customer Usage Attribution
+module modCustomerUsageAttribution '../../../../BrownField/Addons/CUAID/customerUsageAttribution/cuaIdResourceGroup.bicep' = {
+  #disable-next-line no-loc-expr-outside-params
+  name: 'pid-${varCuaid}-${uniqueString(resourceGroup().location)}'
+  params: {}
 }

--- a/Build-ARM.ps1
+++ b/Build-ARM.ps1
@@ -6,7 +6,7 @@ if ($LASTEXITCODE -ne 0) {
 
 Get-ChildItem '.\' -Recurse -Include '*.bicep' |% {
     $source = $_.FullName
-    if (!($source -like "*\Bicep\Modules\*") -and !($source -like "*/Bicep/Modules/*") -and !($source -like "*999-WorkInProgress*")) { 
+    if (!($source -like "*\Bicep\Modules\*") -and !($source -like "*/Bicep/Modules/*") -and !($source -like "*CUAID*") -and !($source -like "*999-WorkInProgress*")) { 
         $folder = $_.Directory.Parent
         $name = $_.BaseName
         $target = Join-Path $folder "ARM\$($name).deploy.json"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Added blank cuaid modules to be called based on deployment scope
Added module to all Brownfield Bicep deployments
Updated Readme

## This PR fixes/adds/changes/removes

1. Added cuaid modules to each brownfield bicep scenario
2. Added readme
3. Added and updated Readmes
4. Updated ARM templates based on Bicep changes

### Breaking Changes

1. None

## Testing Evidence

Tested deployments

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale-for-AVS/pulls)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale-for-AVS/tree/main)
- [X] Performed testing and provided evidence.
- [X] Updated relevant and associated documentation.
