### PR TITLE
Bicep build 0.4.1318

### DIFF
--- a/BrownField/Addons/HCX/ARM/HCX.deploy.json
+++ b/BrownField/Addons/HCX/ARM/HCX.deploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1272.37030",
-      "templateHash": "4939662003978325105"
+      "version": "0.4.1318.3566",
+      "templateHash": "2607521391039134232"
     }
   },
   "parameters": {
@@ -45,8 +45,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1272.37030",
-              "templateHash": "4174488789265615178"
+              "version": "0.4.1318.3566",
+              "templateHash": "10779157790839886898"
             }
           },
           "resources": []

--- a/BrownField/Addons/SRM/ARM/SRM.deploy.json
+++ b/BrownField/Addons/SRM/ARM/SRM.deploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1272.37030",
-      "templateHash": "142440890599000820"
+      "version": "0.4.1318.3566",
+      "templateHash": "7518781036825997223"
     }
   },
   "parameters": {
@@ -72,8 +72,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1272.37030",
-              "templateHash": "4174488789265615178"
+              "version": "0.4.1318.3566",
+              "templateHash": "10779157790839886898"
             }
           },
           "resources": []

--- a/BrownField/Monitoring/AVS-Dashboard/ARM/AVSDashboard.deploy.json
+++ b/BrownField/Monitoring/AVS-Dashboard/ARM/AVSDashboard.deploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1272.37030",
-      "templateHash": "3078573540625338306"
+      "version": "0.4.1318.3566",
+      "templateHash": "1198101896634958778"
     }
   },
   "parameters": {
@@ -376,8 +376,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1272.37030",
-              "templateHash": "4174488789265615178"
+              "version": "0.4.1318.3566",
+              "templateHash": "10779157790839886898"
             }
           },
           "resources": []

--- a/BrownField/Monitoring/AVS-Service-Health/ARM/AVSServiceHealth.deploy.json
+++ b/BrownField/Monitoring/AVS-Service-Health/ARM/AVSServiceHealth.deploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1272.37030",
-      "templateHash": "5146761970804686202"
+      "version": "0.4.1318.3566",
+      "templateHash": "16213799529944616957"
     }
   },
   "parameters": {
@@ -110,8 +110,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1272.37030",
-              "templateHash": "4174488789265615178"
+              "version": "0.4.1318.3566",
+              "templateHash": "10779157790839886898"
             }
           },
           "resources": []

--- a/BrownField/Monitoring/AVS-Utilization-Alerts/ARM/AVSMonitor.deploy.json
+++ b/BrownField/Monitoring/AVS-Utilization-Alerts/ARM/AVSMonitor.deploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1272.37030",
-      "templateHash": "5598468798837012617"
+      "version": "0.4.1318.3566",
+      "templateHash": "9044248135291948382"
     }
   },
   "parameters": {
@@ -207,8 +207,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1272.37030",
-              "templateHash": "4174488789265615178"
+              "version": "0.4.1318.3566",
+              "templateHash": "10779157790839886898"
             }
           },
           "resources": []

--- a/BrownField/Networking/AVS-to-AVS-CrossRegion-GlobalReach/ARM/CrossAVSGlobalReach.deploy.json
+++ b/BrownField/Networking/AVS-to-AVS-CrossRegion-GlobalReach/ARM/CrossAVSGlobalReach.deploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1272.37030",
-      "templateHash": "5388761589278936028"
+      "version": "0.4.1318.3566",
+      "templateHash": "4827878110747686168"
     }
   },
   "parameters": {
@@ -59,8 +59,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1272.37030",
-              "templateHash": "2956281795248563008"
+              "version": "0.4.1318.3566",
+              "templateHash": "12049220193843438421"
             }
           },
           "parameters": {
@@ -102,8 +102,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1272.37030",
-                      "templateHash": "4174488789265615178"
+                      "version": "0.4.1318.3566",
+                      "templateHash": "10779157790839886898"
                     }
                   },
                   "resources": []
@@ -151,8 +151,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1272.37030",
-              "templateHash": "8814019771066365787"
+              "version": "0.4.1318.3566",
+              "templateHash": "3739766238709142225"
             }
           },
           "parameters": {
@@ -204,8 +204,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.4.1272.37030",
-                      "templateHash": "4174488789265615178"
+                      "version": "0.4.1318.3566",
+                      "templateHash": "10779157790839886898"
                     }
                   },
                   "resources": []

--- a/BrownField/Networking/AVS-to-AVS-SameRegion/ARM/CrossAVSWithinRegion.deploy.json
+++ b/BrownField/Networking/AVS-to-AVS-SameRegion/ARM/CrossAVSWithinRegion.deploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1272.37030",
-      "templateHash": "17389485434702717954"
+      "version": "0.4.1318.3566",
+      "templateHash": "5003690178361924099"
     }
   },
   "parameters": {
@@ -50,8 +50,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1272.37030",
-              "templateHash": "4174488789265615178"
+              "version": "0.4.1318.3566",
+              "templateHash": "10779157790839886898"
             }
           },
           "resources": []

--- a/BrownField/Networking/AVS-to-OnPremises-ExpressRoute-GlobalReach/ARM/AVSGlobalReach.deploy.json
+++ b/BrownField/Networking/AVS-to-OnPremises-ExpressRoute-GlobalReach/ARM/AVSGlobalReach.deploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1272.37030",
-      "templateHash": "16882334144361166307"
+      "version": "0.4.1318.3566",
+      "templateHash": "8478330249362910489"
     }
   },
   "parameters": {
@@ -57,8 +57,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1272.37030",
-              "templateHash": "4174488789265615178"
+              "version": "0.4.1318.3566",
+              "templateHash": "10779157790839886898"
             }
           },
           "resources": []

--- a/BrownField/Networking/AVS-to-VNet-ExistingVNet/ARM/ExRConnection.deploy.json
+++ b/BrownField/Networking/AVS-to-VNet-ExistingVNet/ARM/ExRConnection.deploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1272.37030",
-      "templateHash": "13416436112607048732"
+      "version": "0.4.1318.3566",
+      "templateHash": "13961952219294811322"
     }
   },
   "parameters": {
@@ -93,8 +93,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1272.37030",
-              "templateHash": "4533823652273022810"
+              "version": "0.4.1318.3566",
+              "templateHash": "12143954751320121689"
             }
           },
           "parameters": {
@@ -147,8 +147,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1272.37030",
-              "templateHash": "4174488789265615178"
+              "version": "0.4.1318.3566",
+              "templateHash": "10779157790839886898"
             }
           },
           "resources": []

--- a/BrownField/Networking/AVS-to-VNet-NewVNet/ARM/VNetWithExR.deploy.json
+++ b/BrownField/Networking/AVS-to-VNet-NewVNet/ARM/VNetWithExR.deploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1272.37030",
-      "templateHash": "1828596135852320460"
+      "version": "0.4.1318.3566",
+      "templateHash": "9720078940672554606"
     }
   },
   "parameters": {
@@ -193,8 +193,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1272.37030",
-              "templateHash": "4533823652273022810"
+              "version": "0.4.1318.3566",
+              "templateHash": "12143954751320121689"
             }
           },
           "parameters": {
@@ -247,8 +247,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1272.37030",
-              "templateHash": "4174488789265615178"
+              "version": "0.4.1318.3566",
+              "templateHash": "10779157790839886898"
             }
           },
           "resources": []

--- a/BrownField/Networking/ExpressRoute-to-VNet/ARM/ExRConnection.deploy.json
+++ b/BrownField/Networking/ExpressRoute-to-VNet/ARM/ExRConnection.deploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1272.37030",
-      "templateHash": "3778111827064092710"
+      "version": "0.4.1318.3566",
+      "templateHash": "4902497846726742628"
     }
   },
   "parameters": {
@@ -79,8 +79,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1272.37030",
-              "templateHash": "4174488789265615178"
+              "version": "0.4.1318.3566",
+              "templateHash": "10779157790839886898"
             }
           },
           "resources": []

--- a/BrownField/PrivateCloud/AVS-PrivateCloud-WithHCX/ARM/PrivateCloudWithHCX.deploy.json
+++ b/BrownField/PrivateCloud/AVS-PrivateCloud-WithHCX/ARM/PrivateCloudWithHCX.deploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1272.37030",
-      "templateHash": "104972711771768830"
+      "version": "0.4.1318.3566",
+      "templateHash": "13019876098330224681"
     }
   },
   "parameters": {
@@ -104,8 +104,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1272.37030",
-              "templateHash": "4174488789265615178"
+              "version": "0.4.1318.3566",
+              "templateHash": "10779157790839886898"
             }
           },
           "resources": []

--- a/BrownField/PrivateCloud/AVS-PrivateCloud/ARM/PrivateCloud.deploy.json
+++ b/BrownField/PrivateCloud/AVS-PrivateCloud/ARM/PrivateCloud.deploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1272.37030",
-      "templateHash": "3209659292921415579"
+      "version": "0.4.1318.3566",
+      "templateHash": "11258218931935396433"
     }
   },
   "parameters": {
@@ -92,8 +92,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1272.37030",
-              "templateHash": "4174488789265615178"
+              "version": "0.4.1318.3566",
+              "templateHash": "10779157790839886898"
             }
           },
           "resources": []


### PR DESCRIPTION
This PR is a rebuild of all brownfield modules with Bicep version 0.4.1318 (March 2022).

The greenfield/landing zone rebuild is in a separate PR.

There were no major changes in the 0.4.1318 build, this PR is mostly version & hash updates.
