### PR TITLE
Update terraform.tfvars

### DIFF
--- a/AVS-Landing-Zone/GreenField/Terraform/terraform.tfvars
+++ b/AVS-Landing-Zone/GreenField/Terraform/terraform.tfvars
@@ -19,7 +19,7 @@ jumpboxsku    = "Standard_D2as_v4"
 #Virtual network address space and required subnets, can be any CIDR range
 vnetaddressspace   = "192.168.1.0/24"
 gatewaysubnet      = "192.168.1.0/27"
-azurebastionsubnet = "192.168.1.32/27"
+azurebastionsubnet = "192.168.1.64/26"
 jumpboxsubnet      = "192.168.1.128/25"
 
 #Enable or Disable telemetry


### PR DESCRIPTION
Updating subnet for azurebastionsubnet. Azure Bastion resources deployed after November 2, 2021 require a subnet of /26 or larger: https://learn.microsoft.com/en-us/azure/bastion/configuration-settings

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

1. Updates the terraform.tfvars file in AVS-Landing-Zone/Greenfield/Terraform to update the sample address space for azurebastionsubnet. The default value is smaller than currently allowed, and will cause deployments to fail if used.


### Breaking Changes

1. *Replace me*
2. *Replace me*

## Testing Evidence

- *Replace this with any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate)*

## As part of this Pull Request I have

- [x ] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale-for-AVS/pulls)
- [ x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale-for-AVS/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
