### PR TITLE
Add terraform stretch cluster module and scenario

### DIFF
--- a/terraform/modules/avs_private_cloud_stretch_cluster/example.tfvars.template
+++ b/terraform/modules/avs_private_cloud_stretch_cluster/example.tfvars.template
@@ -1,0 +1,17 @@
+  sddc_name                             = "TestSDDC"
+  sddc_sku                              = "av36"
+  management_cluster_size               = 6
+  rg_name                               = "Sample_resource_group_name"
+  rg_location                           = "Southeast Asia"
+  avs_network_cidr                      = "10.0.0.0/22"
+  expressroute_authorization_key_name_1 = "TestSDDC-ExR-AuthKey_1"
+  expressroute_authorization_key_name_2 = "TestSDDC-ExR-AuthKey_2
+  tags                                  = {Sample_key = "Sample_value"}
+  internet_enabled                      = false
+  hcx_enabled                           = true
+  hcx_key_names                         = ["keyname1", "keyname2"]
+  module_telemetry_enabled              = true
+  tags                                  = {
+      environment = "Dev"
+      CreatedBy   = "Terraform"
+  }

--- a/terraform/modules/avs_private_cloud_stretch_cluster/main.tf
+++ b/terraform/modules/avs_private_cloud_stretch_cluster/main.tf
@@ -1,0 +1,166 @@
+data "azurerm_resource_group" "avs" {
+    name = var.rg_name
+}
+
+#generate a random password to use for the initial NSXT admin account password
+resource "random_password" "nsxt" {
+  length           = 14
+  special          = true
+  numeric          = true
+  override_special = "%@#"
+  min_special      = 1
+  min_numeric      = 1
+  min_upper        = 1
+  min_lower        = 1
+}
+
+#generate a random password to use for the initial vcenter cloudadmin account password
+resource "random_password" "vcenter" {
+  length           = 14
+  special          = true
+  numeric          = true
+  override_special = "%@#"
+  min_special      = 1
+  min_numeric      = 1
+  min_upper        = 1
+  min_lower        = 1
+}
+
+#create the private cloud using the azapi resource provider
+resource "azapi_resource" "stretch_cluster" {
+  type = "Microsoft.AVS/privateClouds@2022-05-01"
+  name                = var.sddc_name
+  parent_id           = data.azurerm_resource_group.avs.id
+  location            = var.rg_location  
+  tags                = var.tags
+
+
+  body = jsonencode({
+    properties = {
+      availability = {
+        strategy = "DualZone"
+      }
+      
+      internet = var.internet_enabled
+      managementCluster = {
+        clusterSize = var.management_cluster_size
+      }
+
+      networkBlock = var.avs_network_cidr
+      nsxtPassword = random_password.nsxt.result
+      vcenterPassword = random_password.vcenter.result
+    }
+    sku = {
+      name = lower(var.sddc_sku)
+    }
+  })
+
+  response_export_values = ["properties.circuit.expressRouteID", "properties.secondaryCircuit.expressRouteID"]
+}
+
+#get the private cloud data for use in creating the auth keys
+data "azurerm_vmware_private_cloud" "stretch_cluster" {
+    name = var.sddc_name
+    resource_group_name = data.azurerm_resource_group.avs.name
+
+    depends_on = [
+      azapi_resource.stretch_cluster
+    ]
+}
+
+#get the private cloud data using the azapi provider to get the primary and secondary expressROute ID's
+data "azapi_resource" "stretch_cluster" {
+    name = "teststretch"
+    parent_id = data.azurerm_resource_group.private_cloud.id
+    type = "Microsoft.AVS/privateClouds@2021-12-01"
+    response_export_values = [
+        "properties.circuit.expressRouteID", 
+        "properties.circuit.expressRoutePrivatePeeringID", 
+        "properties.secondaryCircuit.expressRouteID", 
+        "properties.secondaryCircuit.expressRoutePrivatePeeringID"]
+}
+
+#create the primary zone expressroute auth key
+resource "azapi_resource" "authkey_circuit1" {
+    type = "Microsoft.AVS/privateClouds/authorizations@2022-05-01"
+    name = var.expressroute_authorization_key_name_1
+    parent_id = data.azurerm_vmware_private_cloud.stretch_cluster.id
+    body = jsonencode({
+        properties = {           
+            expressRouteId = jsondecode(azapi_resource.stretch_cluster.output).properties.circuit.expressRouteID
+        }
+    })
+    response_export_values = ["properties.expressRouteAuthorizationKey"]
+    schema_validation_enabled = false
+}
+#Create the secondary zone expressroute auth key
+resource "azapi_resource" "authkey_circuit2" {
+    type = "Microsoft.AVS/privateClouds/authorizations@2022-05-01"
+    name = var.expressroute_authorization_key_name_2
+    parent_id = data.azurerm_vmware_private_cloud.stretch_cluster.id
+    body = jsonencode({
+        properties = {           
+            expressRouteId = jsondecode(azapi_resource.stretch_cluster.output).properties.secondaryCircuit.expressRouteID
+        }
+    })
+    response_export_values = ["properties.expressRouteAuthorizationKey"]
+    schema_validation_enabled = false
+}
+
+#deploy the hcx addon if the hcx_enabled variable is set to true
+module "hcx_addon" {
+  count  = var.hcx_enabled ? 1 : 0
+  source = "../avs_addon_hcx"
+
+  private_cloud_name           = data.azurerm_vmware_private_cloud.stretch_cluster.name
+  private_cloud_resource_group = data.azurerm_resource_group.avs.name
+  hcx_key_names                = var.hcx_key_names
+  module_telemetry_enabled     = false
+
+  depends_on = [
+    azapi_resource.stretch_cluster
+  ]
+}
+
+
+#############################################################################################
+# Telemetry Section - Toggled on and off with the telemetry variable
+# This allows us to get deployment frequency statistics for deployments
+# Re-using parts of the Core Enterprise Landing Zone methodology
+#############################################################################################
+locals {
+  #create an empty ARM template to use for generating the deployment value
+  telem_arm_subscription_template_content = <<TEMPLATE
+    {
+      "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+      "contentVersion": "1.0.0.0",
+      "parameters": {},
+      "variables": {},
+      "resources": [],
+      "outputs": {
+        "telemetry": {
+          "type": "String",
+          "value": "For more information, see https://aka.ms/alz/tf/telemetry"
+        }
+      }
+    }
+    TEMPLATE
+  module_identifier                       = lower("avs_private_cloud_stretch_cluster")
+  telem_arm_deployment_name               = "${lower(var.guid_telemetry)}.${substr(local.module_identifier, 0, 20)}.${random_string.telemetry.result}"
+}
+
+#create a random string for uniqueness  
+resource "random_string" "telemetry" {
+  length  = 4
+  special = false
+  upper   = false
+  lower   = true
+}
+
+resource "azurerm_subscription_template_deployment" "telemetry_core" {
+  count = var.module_telemetry_enabled ? 1 : 0
+
+  name             = local.telem_arm_deployment_name
+  location         = azurerm_vmware_private_cloud.privatecloud.location
+  template_content = local.telem_arm_subscription_template_content
+}

--- a/terraform/modules/avs_private_cloud_stretch_cluster/outputs.tf
+++ b/terraform/modules/avs_private_cloud_stretch_cluster/outputs.tf
@@ -1,5 +1,5 @@
 output "sddc_id" {
-  value = data.azurerm_vmware_private_cloud.stretch_cluster.id
+  value = data.azapi_resource.stretch_cluster.id
 }
 
 output "sddc_express_route_id" {
@@ -23,24 +23,30 @@ output "sddc_express_route_private_peering_id" {
   ]
 }
 
+
 output "sddc_vcsa_endpoint" {
-  value = data.azurerm_vmware_private_cloud.stretch_cluster.vcsa_endpoint
+  value = jsondecode(data.azapi_resource.stretch_cluster.output).properties.endpoints.vcsa
 }
 
 output "sddc_nsxt_manager_endpoint" {
-  value = data.azurerm_vmware_private_cloud.stretch_cluster.nsxt_manager_endpoint
+  value = jsondecode(data.azapi_resource.stretch_cluster.output).properties.endpoints.nsxtManager
 }
 
 output "sddc_hcx_cloud_manager_endpoint" {
-  value = data.azurerm_vmware_private_cloud.stretch_cluster.hcx_cloud_manager_endpoint
+  value = jsondecode(data.azapi_resource.stretch_cluster.output).properties.endpoints.hcxCloudManager
 }
 
 output "sddc_provisioning_subnet_cidr" {
-  value = data.azurerm_vmware_private_cloud.stretch_cluster.provisioning_subnet_cidr
+  value = jsondecode(data.azapi_resource.stretch_cluster.output).properties.provisioningNetwork
 }
 
+/*
 #return the hcx keys if hcx is enabled, empty map if not.  
 #output will referenced using an index due to count on module.
 output "hcx_keys" {
   value = module.hcx_addon[*].keys
+}
+*/
+output "full_cluster_details" {
+  value = data.azapi_resource.stretch_cluster
 }

--- a/terraform/modules/avs_private_cloud_stretch_cluster/outputs.tf
+++ b/terraform/modules/avs_private_cloud_stretch_cluster/outputs.tf
@@ -1,0 +1,46 @@
+output "sddc_id" {
+  value = data.azurerm_vmware_private_cloud.stretch_cluster.id
+}
+
+output "sddc_express_route_id" {
+  value = [
+    jsondecode(data.azapi_resource.stretch_cluster.output).properties.circuit.expressRouteID,
+    jsondecode(data.azapi_resource.stretch_cluster.output).properties.secondaryCircuit.expressRouteID
+  ]
+}
+
+output "sddc_express_route_authorization_key" {
+  value = [
+    jsondecode(azapi_resource.authkey_circuit1.output).properties.expressRouteAuthorizationKey,
+    jsondecode(azapi_resource.authkey_circuit2.output).properties.expressRouteAuthorizationKey
+  ]
+}
+
+output "sddc_express_route_private_peering_id" {
+  value = [
+    jsondecode(data.azapi_resource.stretch_cluster.output).properties.circuit.expressRoutePrivatePeeringID,
+    jsondecode(data.azapi_resource.stretch_cluster.output).properties.secondaryCircuit.expressRoutePrivatePeeringID
+  ]
+}
+
+output "sddc_vcsa_endpoint" {
+  value = data.azurerm_vmware_private_cloud.stretch_cluster.vcsa_endpoint
+}
+
+output "sddc_nsxt_manager_endpoint" {
+  value = data.azurerm_vmware_private_cloud.stretch_cluster.nsxt_manager_endpoint
+}
+
+output "sddc_hcx_cloud_manager_endpoint" {
+  value = data.azurerm_vmware_private_cloud.stretch_cluster.hcx_cloud_manager_endpoint
+}
+
+output "sddc_provisioning_subnet_cidr" {
+  value = data.azurerm_vmware_private_cloud.stretch_cluster.provisioning_subnet_cidr
+}
+
+#return the hcx keys if hcx is enabled, empty map if not.  
+#output will referenced using an index due to count on module.
+output "hcx_keys" {
+  value = module.hcx_addon[*].keys
+}

--- a/terraform/modules/avs_private_cloud_stretch_cluster/readme.md
+++ b/terraform/modules/avs_private_cloud_stretch_cluster/readme.md
@@ -1,0 +1,8 @@
+### General 
+
+* Description: This module creates a new AVS stretch cluster and initial expressroute authorization keys for each zone. It exports the expressroute artifacts (authorization key, expressroute ID, and private peering ID) as a list with the primary site having the 0 index and the secondary site the 1 index.  Because the stretch cluster functionality has yet to be released for the AzureRM provider, this configuration provisions the cluster using the AzAPI provider.
+
+* The module leverages variables for naming and common values to be modified as part of the deployment.
+
+* A tfvars template file has been included for use if implementing this module as a standalone deployment.
+

--- a/terraform/modules/avs_private_cloud_stretch_cluster/variables.tf
+++ b/terraform/modules/avs_private_cloud_stretch_cluster/variables.tf
@@ -1,0 +1,82 @@
+#################################################################
+# module variables
+#################################################################
+variable "sddc_name" {
+  type        = string
+  description = "Azure resource name assigned to the avs sddc being created"
+}
+
+variable "sddc_sku" {
+  type        = string
+  description = "The sku value for the AVS SDDC management cluster nodes"
+}
+
+variable "management_cluster_size" {
+  type        = number
+  description = "The number of nodes to include in the management cluster"
+  default     = 3
+}
+
+variable "rg_name" {
+  type        = string
+  description = "Resource Group Name where the expressroute gateway and the associated public ip are being deployed"
+}
+
+variable "rg_location" {
+  type        = string
+  description = "Resource Group location"
+  default     = "westus2"
+}
+
+variable "avs_network_cidr" {
+  type        = string
+  description = "The full /22 network CIDR range summary for the private cloud managed components"
+}
+
+variable "expressroute_authorization_key_name_1" {
+  type        = string
+  description = "The name to use for the expressRoute authorization key for circuit 1"
+}
+
+variable "expressroute_authorization_key_name_2" {
+  type        = string
+  description = "The name to use for the expressRoute authorization key for circuit 2"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "List of the tags that will be assigned to each resource"
+}
+
+variable "internet_enabled" {
+  type        = bool
+  description = "set the internet snat to on or off"
+  default     = false
+}
+
+variable "hcx_enabled" {
+  type        = bool
+  description = "Enable the HCX addon toggle value"
+  default     = false
+}
+
+variable "hcx_key_names" {
+  type        = list(string)
+  description = "list of key names to use when generating hcx site activation keys."
+  default     = []
+}
+
+#################################################################
+# telemetry variables
+#################################################################
+variable "module_telemetry_enabled" {
+  type        = bool
+  description = "toggle the telemetry on/off for this module"
+  default     = true
+}
+
+variable "guid_telemetry" {
+  type        = string
+  description = "guid used for telemetry identification. Defaults to module guid, but overrides with root if needed."
+  default     = "0f9a8adc-9d37-40b3-aaed-ab34b95cf6dd"
+}

--- a/terraform/scenarios/avs_greenfield_stretch_cluster_existing_exr_gateway/input_sample.auto.tfvars.sample
+++ b/terraform/scenarios/avs_greenfield_stretch_cluster_existing_exr_gateway/input_sample.auto.tfvars.sample
@@ -1,0 +1,21 @@
+#This file is a sample tfvars input for this module. 
+#Copy this file to your root module, populate the file with the target deployment values and remove the .sample extension.
+
+
+prefix                  = "SDDC1"
+region                  = "Southeast Asia"
+sddc_sku                = "av36"
+#the cluster size should be a minimum of 6 for the two 3 node clusters to build
+management_cluster_size = 6
+avs_network_cidr        = "192.168.0.0/22"
+hcx_enabled             = true
+hcx_key_names           = ["keyname1", "keyname2"]
+email_addresses         = ["test1@test.com","test2@test.com"]
+expressroute_gateway_id = "<full resource id of the expressroute gateway the private clouds will be connected to>"
+internet_enabled        = false
+tags = {
+  environment = "Dev"
+  CreatedBy   = "Terraform"
+}
+
+telemetry_enabled = true

--- a/terraform/scenarios/avs_greenfield_stretch_cluster_existing_exr_gateway/main.tf
+++ b/terraform/scenarios/avs_greenfield_stretch_cluster_existing_exr_gateway/main.tf
@@ -1,0 +1,129 @@
+# Create local variable derived from an input prefix or modify for customer naming
+locals {
+  #update naming convention with target naming convention if different
+  private_cloud_rg_name                 = "${var.prefix}-PrivateCloud-${random_string.namestring.result}"
+  network_rg_name                       = "${var.prefix}-Network-${random_string.namestring.result}"
+  sddc_name                             = "${var.prefix}-AVS-SDDC-${random_string.namestring.result}"
+  expressroute_authorization_key_name_1 = "${var.prefix}-AVS-ExpressrouteAuthKey-1-${random_string.namestring.result}"
+  expressroute_authorization_key_name_2 = "${var.prefix}-AVS-ExpressrouteAuthKey-2-${random_string.namestring.result}"
+  express_route_connection_name_1       = "${var.prefix}-AVS-ExpressrouteConnection-1-${random_string.namestring.result}"
+  express_route_connection_name_2       = "${var.prefix}-AVS-ExpressrouteConnection-2-${random_string.namestring.result}"
+
+
+  service_health_alert_name = "${var.prefix}-AVS-service-health-alert-${random_string.namestring.result}"
+  action_group_name         = "${var.prefix}-AVS-action-group-${random_string.namestring.result}"
+  action_group_shortname    = "avs-sddc-sh"
+}
+
+
+#create a random string for uniqueness during redeployments using the same values
+resource "random_string" "namestring" {
+  length  = 4
+  special = false
+  upper   = false
+  lower   = true
+}
+
+#Create the private cloud resource group
+resource "azurerm_resource_group" "greenfield_privatecloud" {
+  name     = local.private_cloud_rg_name
+  location = var.region
+}
+
+#deploy a private cloud with a single management cluster and connect to the expressroute gateway
+module "avs_private_cloud" {
+  source = "../../modules/avs_private_cloud_stretch_cluster"
+
+  sddc_name                             = local.sddc_name
+  sddc_sku                              = var.sddc_sku
+  management_cluster_size               = var.management_cluster_size
+  rg_name                               = azurerm_resource_group.greenfield_privatecloud.name
+  rg_location                           = azurerm_resource_group.greenfield_privatecloud.location
+  avs_network_cidr                      = var.avs_network_cidr
+  expressroute_authorization_key_name_1 = local.expressroute_authorization_key_name_1
+  expressroute_authorization_key_name_2 = local.expressroute_authorization_key_name_2
+  internet_enabled                      = var.internet_enabled
+  hcx_enabled                           = var.hcx_enabled
+  hcx_key_names                         = var.hcx_key_names
+  tags                                  = var.tags
+  module_telemetry_enabled              = false
+}
+
+#deploy the default service health and azure monitor alerts
+module "avs_service_health" {
+  source = "../../modules/avs_service_health"
+
+  rg_name                       = azurerm_resource_group.greenfield_privatecloud.name
+  action_group_name             = local.action_group_name
+  action_group_shortname        = local.action_group_shortname
+  email_addresses               = var.email_addresses
+  service_health_alert_name     = local.service_health_alert_name
+  service_health_alert_scope_id = azurerm_resource_group.greenfield_privatecloud.id
+  private_cloud_id              = module.avs_private_cloud.sddc_id
+  module_telemetry_enabled      = false
+}
+
+resource "azurerm_virtual_network_gateway_connection" "avs_1" {
+  name                = local.express_route_connection_name_1
+  location            = azurerm_resource_group.greenfield_privatecloud.location
+  resource_group_name = azurerm_resource_group.greenfield_privatecloud.name
+
+  type                       = "ExpressRoute"
+  virtual_network_gateway_id = var.expressroute_gateway_id
+  express_route_circuit_id   = module.avs_private_cloud.sddc_express_route_id[0]
+  authorization_key          = module.avs_private_cloud.sddc_express_route_authorization_key[0]
+}
+
+resource "azurerm_virtual_network_gateway_connection" "avs_2" {
+  name                = local.express_route_connection_name_2
+  location            = azurerm_resource_group.greenfield_privatecloud.location
+  resource_group_name = azurerm_resource_group.greenfield_privatecloud.name
+
+  type                       = "ExpressRoute"
+  virtual_network_gateway_id = var.expressroute_gateway_id
+  express_route_circuit_id   = module.avs_private_cloud.sddc_express_route_id[1]
+  authorization_key          = module.avs_private_cloud.sddc_express_route_authorization_key[1]
+}
+
+#############################################################################################
+# Telemetry Section - Toggled on and off with the telemetry variable
+# This allows us to get deployment frequency statistics for deployments
+# Re-using parts of the Core Enterprise Landing Zone methodology
+#############################################################################################
+locals {
+  #create an empty ARM template to use for generating the deployment value
+  telem_arm_subscription_template_content = <<TEMPLATE
+    {
+      "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+      "contentVersion": "1.0.0.0",
+      "parameters": {},
+      "variables": {},
+      "resources": [],
+      "outputs": {
+        "telemetry": {
+          "type": "String",
+          "value": "For more information, see https://aka.ms/alz/tf/telemetry"
+        }
+      }
+    }
+    TEMPLATE
+  module_identifier                       = lower("avs_greenfield_stretch_cluster_existing_exr_gateway")
+  telem_arm_deployment_name               = "fd6adce1-fd57-4849-8675-f2164bdbb099.${substr(local.module_identifier, 0, 20)}.${random_string.telemetry.result}"
+}
+
+#create a random string for uniqueness  
+resource "random_string" "telemetry" {
+  length  = 4
+  special = false
+  upper   = false
+  lower   = true
+}
+
+resource "azurerm_subscription_template_deployment" "telemetry_core" {
+  count = var.telemetry_enabled ? 1 : 0
+
+  name             = local.telem_arm_deployment_name
+  provider         = azurerm
+  location         = azurerm_resource_group.greenfield_privatecloud.location
+  template_content = local.telem_arm_subscription_template_content
+}

--- a/terraform/scenarios/avs_greenfield_stretch_cluster_existing_exr_gateway/outputs.tf
+++ b/terraform/scenarios/avs_greenfield_stretch_cluster_existing_exr_gateway/outputs.tf
@@ -2,18 +2,6 @@ output "sddc_id" {
   value = module.avs_private_cloud.sddc_id
 }
 
-output "sddc_express_route_id" {
-  value = module.avs_private_cloud.sddc_express_route_id
-}
-
-output "sddc_express_route_private_peering_id" {
-  value = module.avs_private_cloud.sddc_express_route_private_peering_id
-}
-
-output "sddc_express_route_authorization_key" {
-  value = module.avs_private_cloud.sddc_express_route_authorization_key
-}
-
 output "sddc_vcsa_endpoint" {
   value = module.avs_private_cloud.sddc_vcsa_endpoint
 }
@@ -30,6 +18,13 @@ output "sddc_provisioning_subnet_cidr" {
   value = module.avs_private_cloud.sddc_provisioning_subnet_cidr
 }
 
+/* #removing HCX output for now as pre-GA stretch clusters require a support case to activate HCX. 
+#UnComment this section after the GA date
 output "hcx_keys" {
   value = module.avs_private_cloud.hcx_keys
+}
+*/
+
+output "full_cluster_details" {
+  value = jsondecode(module.avs_private_cloud.full_cluster_details.output)
 }

--- a/terraform/scenarios/avs_greenfield_stretch_cluster_existing_exr_gateway/outputs.tf
+++ b/terraform/scenarios/avs_greenfield_stretch_cluster_existing_exr_gateway/outputs.tf
@@ -1,0 +1,35 @@
+output "sddc_id" {
+  value = module.avs_private_cloud.sddc_id
+}
+
+output "sddc_express_route_id" {
+  value = module.avs_private_cloud.sddc_express_route_id
+}
+
+output "sddc_express_route_private_peering_id" {
+  value = module.avs_private_cloud.sddc_express_route_private_peering_id
+}
+
+output "sddc_express_route_authorization_key" {
+  value = module.avs_private_cloud.sddc_express_route_authorization_key
+}
+
+output "sddc_vcsa_endpoint" {
+  value = module.avs_private_cloud.sddc_vcsa_endpoint
+}
+
+output "sddc_nsxt_manager_endpoint" {
+  value = module.avs_private_cloud.sddc_nsxt_manager_endpoint
+}
+
+output "sddc_hcx_cloud_manager_endpoint" {
+  value = module.avs_private_cloud.sddc_hcx_cloud_manager_endpoint
+}
+
+output "sddc_provisioning_subnet_cidr" {
+  value = module.avs_private_cloud.sddc_provisioning_subnet_cidr
+}
+
+output "hcx_keys" {
+  value = module.avs_private_cloud.hcx_keys
+}

--- a/terraform/scenarios/avs_greenfield_stretch_cluster_existing_exr_gateway/providers.tf
+++ b/terraform/scenarios/avs_greenfield_stretch_cluster_existing_exr_gateway/providers.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~>3.00"
+    }
+    azapi = {
+      source  = "azure/azapi"
+      version = "~>1.1.0"
+    }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~>2.30.0"
+    }
+  }
+
+  #This block can be populated and uncommented if using Azure Storage for remote state
+  /*
+  backend "azurerm" {
+    resource_group_name  = "<tfstate storage account resource group name>"
+    storage_account_name = "<tfstate storage account name>"
+    container_name       = "<tfstate blob container name>"
+    key                  = "<tfstate file name>"
+    use_azuread_auth     = true
+    subscription_id      = "<subscription guid for the tfstate storage account>"
+    tenant_id            = "<Azure AD tenant guid for the tfstate storage account>"
+  }
+*/
+  required_version = ">= 1.0"
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/terraform/scenarios/avs_greenfield_stretch_cluster_existing_exr_gateway/readme.md
+++ b/terraform/scenarios/avs_greenfield_stretch_cluster_existing_exr_gateway/readme.md
@@ -1,0 +1,78 @@
+# Implement AVS Stretch Cluster with intergration to existing ExpressRoute Gateway
+
+## Table of contents
+
+- [Scenario Details](#scenario-details)
+- [Scenario Implementation - Manual Steps](#scenario-implementation-with-manual-steps)
+- [Scenario Implementation - Automation Options](#automation-implementation)
+- [Appendix](#appendix)
+
+
+## Scenario Details
+
+### Overview
+This scenario is meant for customers who want to implement a greenfield AVS stretch cluster environment using expressroute to make the hybrid connection. The solution implements a new stretch cluster and makes connections from each zone to the provided id for the existing expressRoute gateway.  AVS Landing Zone concepts can be explored in more detail via the [official documentation page](https://docs.microsoft.com/en-us/azure/cloud-adoption-framework/scenarios/azure-vmware/ready). 
+
+### Naming
+
+Resource naming is configured by using local variables at the top of the root module.  Each name is configured to use a static prefix value that is provided via an input variable and a randomly generated 4 character suffix for uniqueness. It is expected that customers may find this naming to be inconsistent with their unique corporate naming conventions, so all the names are maintained in the locals for simplicity in modifying the naming during deployment. 
+
+### Internet Ingress/Egress
+Internet egress for AVS can be enabled with the internet_enabled toggle or by using an existing NVA to advertise the 0.0.0.0/0 route to AVS for internet access. Internet ingress is not covered in this scenario, but can be enabled through one of the standard AVS mechanisms.
+
+### Network Inspection
+Network inspection is out of scope for this scenario, but can be added using standard NVA mechanisms either within the private cloud, Azure, or on-premises.
+
+### Assumptions
+
+- This configuration covers a basic implementation of a stretch cluster integrating to an expressroute gateway
+
+[(Back to top)](#table-of-contents)
+
+## Scenario implementation with manual steps
+The steps described below are an outline for deploying this scenario manually. If you wish to use the accompanying automation, then skip to the automation guidance below the manual workflow.
+
+These steps represent deploying a configuration using the portal and vcenter.
+
+- Create the required **resource groups** in the target subscription
+    - Private Cloud - used to deploy the private cloud and any associated resources
+
+- Deploy the **AVS private cloud**
+    - Create a private cloud stretch cluster with an initial management cluster
+    - Do not enable the internet access toggle as a default
+    - Upon deployment completion, create the initial expressroute authorization keys 
+
+- Create **Service Health Alerts** for the AVS SLA related items
+    Name    | Description | Metric | SplitDimension | Threshold | Severity 
+    ---     | :---:       | :---:  | :---:          | :---:     | :---:
+    **CPU**     | CPU Usage per Cluster | EffectiveCpuAverage | clustername | 80 | 2
+    **Memory**  | Memory Usage per Cluster | UsageAverage     | clustername | 80 | 2 
+    **Storage** | Storage Usage per Datastore | DiskUsedPercentage | dsname | 70 | 2 
+    **StorageCritical** | Storage Usage per Datastore| DiskUsedPercentage | dsname | 75 | 0 
+
+- Configure the AVS guest network elements 
+    - Configure a new DHCP server
+    - Create a new segment and link to the DHCP server
+    - Create a DNS scope on the AVS private cloud for any custom DNS required for LDAP configuration
+- Deploy a test VM into AVS 
+    - <TODO: determine guest configuration and testing >
+- Test the connectivity
+
+
+[(Back to top)](#table-of-contents)
+## Automation implementation
+
+This scenario is organized using a root module included in this folder, and a number of child modules included in the modules subdirectory of the terraform directory of this repo.  This root module includes a tfvars sample file that contains an example set of input values. This module also includes a sample providers file that can be modified to fit your specific environment.
+
+To deploy this module, ensure you have a deployment resource that meets the pre-requisites for Azure Deployments with terraform. Clone this repo to a local directory on the deployment machine.  Update the providers and tfvars sample files and remove the .sample extension.
+
+Execute the terraform init/plan/apply workflow to execute the deployment.
+
+[(Back to top)](#table-of-contents)
+
+## Appendix
+
+
+
+
+[(Back to top)](#table-of-contents)

--- a/terraform/scenarios/avs_greenfield_stretch_cluster_existing_exr_gateway/variables.tf
+++ b/terraform/scenarios/avs_greenfield_stretch_cluster_existing_exr_gateway/variables.tf
@@ -1,0 +1,67 @@
+variable "prefix" {
+  type        = string
+  description = "Simple prefix used for naming convention prepending"
+}
+
+variable "region" {
+  type        = string
+  description = "Deployment region for the new AVS private cloud resources"
+}
+
+
+
+variable "sddc_sku" {
+  type        = string
+  description = "The sku value for the AVS SDDC management cluster nodes"
+  default     = "av36"
+}
+
+variable "management_cluster_size" {
+  type        = number
+  description = "The number of nodes to include in the management cluster"
+  default     = 3
+}
+
+variable "avs_network_cidr" {
+  type        = string
+  description = "The full /22 network CIDR range summary for the private cloud managed components"
+}
+
+variable "expressroute_gateway_id" {
+  type        = string
+  description = "the gateway ID of the expressRoute gateway being connected"
+}
+
+variable "hcx_enabled" {
+  type        = bool
+  description = "Enable the HCX addon toggle value"
+  default     = false
+}
+
+variable "hcx_key_names" {
+  type        = list(string)
+  description = "list of key names to use when generating hcx site activation keys."
+  default     = []
+}
+
+variable "internet_enabled" {
+  type        = bool
+  description = "set the internet snat to on or off"
+  default     = false
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "List of the tags that will be assigned to each resource"
+}
+
+variable "email_addresses" {
+  type        = list(string)
+  description = "A list of email addresses where service health alerts will be sent"
+}
+
+variable "telemetry_enabled" {
+  type        = bool
+  description = "toggle the telemetry on/off for this module"
+  default     = true
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary
Creates a terraform module and scenario for a basic AVS private cloud stretch cluster with ExpressRoute connectivity.  The HCX module has been temporarily removed as it requires a support case to activate until the stretch cluster feature goes GA.

Both module and scenario include basic documentation and telemetry configurations.

## This PR fixes/adds/changes/removes

1. Adds stretch cluster private cloud module to terraform modules library
2. Adds a scenario sample that configures a greenfield stretch cluster private cloud and connects it to an existing expressRoute gateway.

### Breaking Changes



## Testing Evidence
![image](https://user-images.githubusercontent.com/84210452/220952168-bdde3829-53e5-4121-bea1-3466565fa292.png)


- *Replace this with any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate)*

## As part of this Pull Request I have

- [x ] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale-for-AVS/pulls)
- [x ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale-for-AVS/tree/main)
- [ x] Performed testing and provided evidence.
- [x ] Updated relevant and associated documentation.
