### PR TITLE
syslog filtering sample for use in truncating AVS syslogs

### DIFF
--- a/terraform/modules/avs_event_hub_for_logs/main.tf
+++ b/terraform/modules/avs_event_hub_for_logs/main.tf
@@ -1,0 +1,106 @@
+########################################################################################
+#Deploy the Event hub items
+########################################################################################
+#Deploy the event hub namespace
+resource "azurerm_eventhub_namespace" "avs_log_processing" {
+  name                = var.eventhub_namespace_name
+  location            = var.rg_location
+  resource_group_name = var.rg_name
+  sku                 = "Standard"
+  capacity            = var.eventhub_capacity
+
+  tags = var.tags
+}
+
+#deploy the event hub 
+resource "azurerm_eventhub" "avs_log_processing" {
+  name                = var.eventhub_name
+  namespace_name      = azurerm_eventhub_namespace.avs_log_processing.name
+  resource_group_name = var.rg_name
+  partition_count     = var.eventhub_partition_count
+  message_retention   = var.eventhub_message_retention_days
+}
+
+#deploy the authorization rule for the diagnostic setting
+resource "azurerm_eventhub_namespace_authorization_rule" "avs_log_processing" {
+  name                = var.diagnostic_eventhub_authorization_rule_name
+  namespace_name      = azurerm_eventhub_namespace.avs_log_processing.name
+  resource_group_name = var.rg_name
+
+  listen = true
+  send   = true
+  manage = true
+}
+
+#deploy the authorization rule for the plugin
+resource "azurerm_eventhub_authorization_rule" "avs_log_processing" {
+  name                = var.logstash_eventhub_authorization_rule_name
+  namespace_name      = azurerm_eventhub_namespace.avs_log_processing.name
+  eventhub_name       = azurerm_eventhub.avs_log_processing.name
+  resource_group_name = var.rg_name
+
+  listen = true
+  send   = true
+  manage = true
+}
+
+#deploy an eventhub consumer group for use by the logstash plugin
+resource "azurerm_eventhub_consumer_group" "avs_log_processing" {
+  name                = var.consumer_group_name
+  namespace_name      = azurerm_eventhub_namespace.avs_log_processing.name
+  eventhub_name       = azurerm_eventhub.avs_log_processing.name
+  resource_group_name = var.rg_name
+}
+
+#deploy a storage account for use by the eventhub plugin to maintain state
+resource "azurerm_storage_account" "avs_log_processing" {
+  name                     = var.plugin_storage_account_name
+  resource_group_name      = var.rg_name
+  location                 = var.rg_location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags = var.tags
+}
+
+#############################################################################################
+# Telemetry Section - Toggled on and off with the telemetry variable
+# This allows us to get deployment frequency statistics for deployments
+# Re-using parts of the Core Enterprise Landing Zone methodology
+#############################################################################################
+locals {
+  #create an empty ARM template to use for generating the deployment value
+  telem_arm_subscription_template_content = <<TEMPLATE
+    {
+      "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+      "contentVersion": "1.0.0.0",
+      "parameters": {},
+      "variables": {},
+      "resources": [],
+      "outputs": {
+        "telemetry": {
+          "type": "String",
+          "value": "For more information, see https://aka.ms/alz/tf/telemetry"
+        }
+      }
+    }
+    TEMPLATE
+  module_identifier                       = lower("avs_event_hub_for_logs")
+  telem_arm_deployment_name               = "${lower(var.guid_telemetry)}.${substr(local.module_identifier, 0, 20)}.${random_string.telemetry.result}"
+}
+
+#create a random string for uniqueness  
+resource "random_string" "telemetry" {
+  length  = 4
+  special = false
+  upper   = false
+  lower   = true
+}
+
+resource "azurerm_subscription_template_deployment" "telemetry_core" {
+  count = var.module_telemetry_enabled ? 1 : 0
+
+  name             = local.telem_arm_deployment_name
+  location         = var.rg_location
+  template_content = local.telem_arm_subscription_template_content
+}

--- a/terraform/modules/avs_event_hub_for_logs/outputs.tf
+++ b/terraform/modules/avs_event_hub_for_logs/outputs.tf
@@ -1,0 +1,19 @@
+output "event_hub_connection_string" {
+  value = azurerm_eventhub_authorization_rule.avs_log_processing.primary_connection_string
+}
+
+output "event_hub_consumer_group_name" {
+  value = azurerm_eventhub_consumer_group.avs_log_processing.name
+}
+
+output "event_hub_storage_account_name" {
+  value = azurerm_storage_account.avs_log_processing.primary_connection_string
+}
+
+output "event_hub_name" {
+  value = azurerm_eventhub.avs_log_processing.name
+}
+
+output "event_hub_authorization_rule_id" {
+  value = azurerm_eventhub_namespace_authorization_rule.avs_log_processing.id
+}

--- a/terraform/modules/avs_event_hub_for_logs/readme.md
+++ b/terraform/modules/avs_event_hub_for_logs/readme.md
@@ -1,0 +1,8 @@
+### General 
+
+* Description: This module creates an event hub namespace, eventhub, and consumer group as well as the two authorization rules used for processing.  It also creates a storage account that is used by the event hub plugin as a witness to enable multiple consumers.
+
+* The module leverages variables for naming and common values to be modified as part of the deployment.
+
+
+

--- a/terraform/modules/avs_event_hub_for_logs/variables.tf
+++ b/terraform/modules/avs_event_hub_for_logs/variables.tf
@@ -1,0 +1,78 @@
+variable "rg_name" {
+  type        = string
+  description = "The azure resource name for the resource group"
+}
+
+variable "rg_location" {
+  description = "Resource Group region location"
+  default     = "westus2"
+}
+
+variable "eventhub_namespace_name" {
+  type        = string
+  description = "The name for the eventhub namespace"
+}
+
+variable "eventhub_capacity" {
+  type        = number
+  description = "The number of eventhub capacity units on the namespace"
+  default     = 8
+}
+
+variable "eventhub_name" {
+  type        = string
+  description = "The name of the eventhub where the logs are being sent"
+}
+
+variable "eventhub_partition_count" {
+  type        = number
+  description = "The number of partitions for the eventhub"
+  default     = 2
+}
+
+variable "eventhub_message_retention_days" {
+  type        = number
+  description = "The number of days for message retention"
+  default     = 3
+}
+
+variable "diagnostic_eventhub_authorization_rule_name" {
+  type        = string
+  description = "Name for the authorization rule used by the eventhub diagnostic setting"
+}
+
+variable "logstash_eventhub_authorization_rule_name" {
+  type        = string
+  description = "Name for the authorization rule used by the logstash event hub plugin"
+}
+
+variable "consumer_group_name" {
+  type        = string
+  description = "The consumer group name for the event hub plugin to process the logs."
+}
+
+variable "plugin_storage_account_name" {
+  type        = string
+  description = "The storage account name for the storage account used by the logstash event hub plugin as a witness."
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "List of the tags that will be assigned to each resource"
+}
+
+#################################################################
+# telemetry variables
+#################################################################
+variable "module_telemetry_enabled" {
+  type        = bool
+  description = "toggle the telemetry on/off for this module"
+  default     = true
+}
+
+variable "guid_telemetry" {
+  type        = string
+  description = "guid used for telemetry identification. Defaults to module guid, but overrides with root if needed."
+  default     = "0f9a8adc-9d37-40b3-aaed-ab34b95cf6dd"
+}
+

--- a/terraform/modules/avs_log_analytics_w_custom_syslog/main.tf
+++ b/terraform/modules/avs_log_analytics_w_custom_syslog/main.tf
@@ -1,0 +1,182 @@
+#Deploy the Log Analytics workspace
+resource "azurerm_log_analytics_workspace" "avs_log_workspace" {
+  name                = var.log_analytics_name
+  location            = var.rg_location
+  resource_group_name = var.rg_name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+
+  tags = var.tags
+}
+
+#create a custom table
+resource "azapi_resource" "law_table" {
+  name      = var.custom_table_name
+  parent_id = azurerm_log_analytics_workspace.avs_log_workspace.id
+  type      = "Microsoft.OperationalInsights/workspaces/tables@2022-10-01"
+  body = jsonencode(
+    {
+      "properties" : {
+        "plan" : "Analytics"
+        "schema" : {
+          "name" : "${var.custom_table_name}",
+          "columns" : [
+            {
+              "name" : "Facility",
+              "type" : "string"
+            },
+            {
+              "name" : "LogCreationTime",
+              "type" : "datetime"
+            },
+            {
+              "name" : "TimeGenerated",
+              "type" : "datetime"
+            },
+            {
+              "name" : "ResourceId",
+              "type" : "string"
+            },
+            {
+              "name" : "Severity",
+              "type" : "string"
+            },
+            {
+              "name" : "Message",
+              "type" : "string"
+            }
+          ]
+        }
+      }
+    }
+  )
+}
+
+
+###########################################################################################################
+# Create a data collection endpoint and data collection rule.  Authorize the service principal to the rule
+###########################################################################################################
+
+#Create the DCE
+resource "azurerm_monitor_data_collection_endpoint" "avs_log_processing_dce" {
+  name                          = var.data_collection_endpoint_name
+  resource_group_name           = var.rg_name
+  location                      = var.rg_location
+  public_network_access_enabled = true
+  description                   = "monitor_data_collection_endpoint for AVS log processing"
+  tags                          = var.tags
+
+  depends_on = [
+    azapi_resource.law_table
+  ]
+}
+
+#Create the DCR
+resource "azurerm_monitor_data_collection_rule" "avs_log_processing_dcr" {
+  name                        = var.data_collection_rule_name
+  resource_group_name         = var.rg_name
+  location                    = var.rg_location
+  data_collection_endpoint_id = azurerm_monitor_data_collection_endpoint.avs_log_processing_dce.id
+
+  destinations {
+    log_analytics {
+      workspace_resource_id = azurerm_log_analytics_workspace.avs_log_workspace.id
+      name                  = azurerm_log_analytics_workspace.avs_log_workspace.name
+    }
+  }
+
+  data_flow {
+    streams       = ["Custom-${var.custom_table_name}"]
+    destinations  = ["${azurerm_log_analytics_workspace.avs_log_workspace.name}"]
+    output_stream = "Custom-${var.custom_table_name}"
+    transform_kql = "source"
+  }
+
+  data_sources {}
+
+  stream_declaration {
+    stream_name = "Custom-${var.custom_table_name}"
+    column {
+      name = "Facility"
+      type = "string"
+    }
+    column {
+      name = "LogCreationTime"
+      type = "datetime"
+    }
+    column {
+      name = "TimeGenerated"
+      type = "datetime"
+    }
+    column {
+      name = "ResourceId"
+      type = "string"
+    }
+    column {
+      name = "Severity"
+      type = "string"
+    }
+    column {
+      name = "Message"
+      type = "string"
+    }
+  }
+
+  description = "data collection rule example"
+  tags        = var.tags
+  depends_on = [
+    azapi_resource.law_table
+  ]
+}
+
+#Permission the DCR
+resource "azurerm_role_assignment" "log_service_principal_dcr_assignment" {
+  scope                = azurerm_monitor_data_collection_rule.avs_log_processing_dcr.id
+  role_definition_name = "Monitoring Metrics Publisher"
+  principal_id         = var.log_processing_principal_object_id
+  depends_on = [
+    azapi_resource.law_table
+  ]
+}
+
+#############################################################################################
+# Telemetry Section - Toggled on and off with the telemetry variable
+# This allows us to get deployment frequency statistics for deployments
+# Re-using parts of the Core Enterprise Landing Zone methodology
+#############################################################################################
+locals {
+  #create an empty ARM template to use for generating the deployment value
+  telem_arm_subscription_template_content = <<TEMPLATE
+    {
+      "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+      "contentVersion": "1.0.0.0",
+      "parameters": {},
+      "variables": {},
+      "resources": [],
+      "outputs": {
+        "telemetry": {
+          "type": "String",
+          "value": "For more information, see https://aka.ms/alz/tf/telemetry"
+        }
+      }
+    }
+    TEMPLATE
+  module_identifier                       = lower("avs_log_analytics_w_custom_syslog")
+  telem_arm_deployment_name               = "${lower(var.guid_telemetry)}.${substr(local.module_identifier, 0, 20)}.${random_string.telemetry.result}"
+}
+
+#create a random string for uniqueness  
+resource "random_string" "telemetry" {
+  length  = 4
+  special = false
+  upper   = false
+  lower   = true
+}
+
+resource "azurerm_subscription_template_deployment" "telemetry_core" {
+  count = var.module_telemetry_enabled ? 1 : 0
+
+  name             = local.telem_arm_deployment_name
+  location         = var.rg_location
+  template_content = local.telem_arm_subscription_template_content
+}

--- a/terraform/modules/avs_log_analytics_w_custom_syslog/outputs.tf
+++ b/terraform/modules/avs_log_analytics_w_custom_syslog/outputs.tf
@@ -1,0 +1,11 @@
+output "logs_ingestion_endpoint" {
+  value = azurerm_monitor_data_collection_endpoint.avs_log_processing_dce.logs_ingestion_endpoint
+}
+
+output "dcr_immutable_id" {
+  value = azurerm_monitor_data_collection_rule.avs_log_processing_dcr.immutable_id
+}
+
+output "dcr_stream_name" {
+  value = "Custom-${var.custom_table_name}"
+}

--- a/terraform/modules/avs_log_analytics_w_custom_syslog/providers.tf
+++ b/terraform/modules/avs_log_analytics_w_custom_syslog/providers.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~>3.00"
+    }
+    azapi = {
+      source  = "azure/azapi"
+      version = "~>1.7.0"
+    }
+  }
+}
+

--- a/terraform/modules/avs_log_analytics_w_custom_syslog/readme.md
+++ b/terraform/modules/avs_log_analytics_w_custom_syslog/readme.md
@@ -1,0 +1,8 @@
+### General 
+
+* Description: This module creates a log analytics workspace and custom table for use in the syslog filtering module.  
+
+* The module leverages variables for naming and common values to be modified as part of the deployment.
+
+
+

--- a/terraform/modules/avs_log_analytics_w_custom_syslog/variables.tf
+++ b/terraform/modules/avs_log_analytics_w_custom_syslog/variables.tf
@@ -1,0 +1,55 @@
+variable "rg_name" {
+  type        = string
+  description = "The azure resource name for the resource group"
+}
+
+variable "rg_location" {
+  description = "Resource Group region location"
+  default     = "westus2"
+}
+
+
+variable "log_analytics_name" {
+  type        = string
+  description = "The name of the log analytics workspace that will receive the syslogs"
+}
+
+variable "custom_table_name" {
+  type        = string
+  description = "The name for the custom table that will hold the syslogs"
+}
+
+variable "data_collection_endpoint_name" {
+  type        = string
+  description = "The name for the data collection endpoint that the logstash log analytics plugin uses"
+}
+
+variable "data_collection_rule_name" {
+  type        = string
+  description = "Name of the data collection rule used by the logstash log analytics plugin"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "List of the tags that will be assigned to each resource"
+}
+
+variable "log_processing_principal_object_id" {
+  type        = string
+  description = "object id of the log processing service principal"
+}
+
+#################################################################
+# telemetry variables
+#################################################################
+variable "module_telemetry_enabled" {
+  type        = bool
+  description = "toggle the telemetry on/off for this module"
+  default     = true
+}
+
+variable "guid_telemetry" {
+  type        = string
+  description = "guid used for telemetry identification. Defaults to module guid, but overrides with root if needed."
+  default     = "0f9a8adc-9d37-40b3-aaed-ab34b95cf6dd"
+}

--- a/terraform/modules/avs_log_filtering_accounts/main.tf
+++ b/terraform/modules/avs_log_filtering_accounts/main.tf
@@ -1,0 +1,65 @@
+########################################################################################
+#Create an AD application registration service principal and password
+########################################################################################
+data "azuread_client_config" "current" {}
+
+resource "azuread_application" "log_processing_principal" {
+  display_name = var.avs_log_processing_service_principal_name
+  owners       = [data.azuread_client_config.current.object_id]
+}
+
+resource "azuread_service_principal" "log_procesing_principal" {
+  application_id               = azuread_application.log_processing_principal.application_id
+  app_role_assignment_required = false
+  owners                       = [data.azuread_client_config.current.object_id]
+}
+
+resource "azuread_service_principal_password" "log_procesing_principal" {
+  service_principal_id = azuread_service_principal.log_procesing_principal.object_id
+}
+
+resource "azuread_application_password" "log_processing_principal" {
+  application_object_id = azuread_application.log_processing_principal.object_id
+}
+
+#############################################################################################
+# Telemetry Section - Toggled on and off with the telemetry variable
+# This allows us to get deployment frequency statistics for deployments
+# Re-using parts of the Core Enterprise Landing Zone methodology
+#############################################################################################
+locals {
+  #create an empty ARM template to use for generating the deployment value
+  telem_arm_subscription_template_content = <<TEMPLATE
+    {
+      "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+      "contentVersion": "1.0.0.0",
+      "parameters": {},
+      "variables": {},
+      "resources": [],
+      "outputs": {
+        "telemetry": {
+          "type": "String",
+          "value": "For more information, see https://aka.ms/alz/tf/telemetry"
+        }
+      }
+    }
+    TEMPLATE
+  module_identifier                       = lower("avs_log_filtering_accounts")
+  telem_arm_deployment_name               = "${lower(var.guid_telemetry)}.${substr(local.module_identifier, 0, 20)}.${random_string.telemetry.result}"
+}
+
+#create a random string for uniqueness  
+resource "random_string" "telemetry" {
+  length  = 4
+  special = false
+  upper   = false
+  lower   = true
+}
+
+resource "azurerm_subscription_template_deployment" "telemetry_core" {
+  count = var.module_telemetry_enabled ? 1 : 0
+
+  name             = local.telem_arm_deployment_name
+  location         = var.rg_location
+  template_content = local.telem_arm_subscription_template_content
+}

--- a/terraform/modules/avs_log_filtering_accounts/outputs.tf
+++ b/terraform/modules/avs_log_filtering_accounts/outputs.tf
@@ -1,0 +1,11 @@
+output "logging_object_id" {
+  value = azuread_service_principal.log_procesing_principal.object_id
+}
+
+output "logging_application_id" {
+  value = azuread_application.log_processing_principal.application_id
+}
+
+output "logging_application_secret" {
+  value = azuread_application_password.log_processing_principal.value
+}

--- a/terraform/modules/avs_log_filtering_accounts/readme.md
+++ b/terraform/modules/avs_log_filtering_accounts/readme.md
@@ -1,0 +1,8 @@
+### General 
+
+* Description: This module creates an azure ad application, service principal and secret for use by the log filtering module. 
+
+* The module leverages variables for naming and common values to be modified as part of the deployment.
+
+
+

--- a/terraform/modules/avs_log_filtering_accounts/variables.tf
+++ b/terraform/modules/avs_log_filtering_accounts/variables.tf
@@ -1,0 +1,19 @@
+variable "avs_log_processing_service_principal_name" {
+  type        = string
+  description = "The name used for the log processing service principal"
+}
+
+#################################################################
+# telemetry variables
+#################################################################
+variable "module_telemetry_enabled" {
+  type        = bool
+  description = "toggle the telemetry on/off for this module"
+  default     = true
+}
+
+variable "guid_telemetry" {
+  type        = string
+  description = "guid used for telemetry identification. Defaults to module guid, but overrides with root if needed."
+  default     = "0f9a8adc-9d37-40b3-aaed-ab34b95cf6dd"
+}

--- a/terraform/modules/avs_log_filtering_vm/main.tf
+++ b/terraform/modules/avs_log_filtering_vm/main.tf
@@ -1,0 +1,142 @@
+
+######################################################################################################################
+# Build and configure the logstash vm
+######################################################################################################################
+resource "random_password" "keystore_password" {
+  length  = 20
+  special = false
+  upper   = true
+  lower   = true
+}
+
+#generate the cloud init config file
+data "template_file" "configure_logstash" {
+  template = file("${path.module}/templates/configure_logstash.yaml")
+
+  vars = {
+    eventHubConnectionString                    = var.logstash_values.eventHubConnectionString
+    eventHubConsumerGroupName                   = var.logstash_values.eventHubConsumerGroupName
+    eventHubInputStorageAccountConnectionString = var.logstash_values.eventHubInputStorageAccountConnectionString
+    logstashKeyStorePassword                    = random_password.keystore_password.result
+    lawPluginAppId                              = var.logstash_values.lawPluginAppId
+    lawPluginAppSecret                          = var.logstash_values.lawPluginAppSecret
+    lawPluginTenantId                           = var.logstash_values.lawPluginTenantId
+    lawPluginDataCollectionEndpointURI          = var.logstash_values.lawPluginDataCollectionEndpointURI
+    lawPluginDcrImmutableId                     = var.logstash_values.lawPluginDcrImmutableId
+    lawPluginDcrStreamName                      = var.logstash_values.lawPluginDcrStreamName
+  }
+}
+
+data "template_cloudinit_config" "config" {
+  gzip          = false
+  base64_encode = true
+
+  # Main cloud-config configuration file.
+  part {
+    filename     = "init.cfg"
+    content_type = "text/cloud-config"
+    content      = data.template_file.configure_logstash.rendered
+  }
+}
+
+resource "random_password" "admin_password" {
+  length  = 20
+  special = false
+  upper   = true
+  lower   = true
+}
+
+resource "azurerm_network_interface" "logstash_nic" {
+  name                = "${var.vm_name}-nic-1"
+  location            = var.rg_location
+  resource_group_name = var.rg_name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = var.logstash_subnet_id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "logstash_vm" {
+  name                            = var.vm_name
+  resource_group_name             = var.rg_name
+  location                        = var.rg_location
+  size                            = var.vm_sku #"Standard_E2as_v5"
+  admin_username                  = "azureuser"
+  admin_password                  = random_password.admin_password.result
+  disable_password_authentication = false
+  custom_data                     = data.template_cloudinit_config.config.rendered
+
+  network_interface_ids = [
+    azurerm_network_interface.logstash_nic.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-focal"
+    sku       = "20_04-lts-gen2"
+    version   = "latest"
+  }
+}
+
+#write secret to keyvault
+resource "azurerm_key_vault_secret" "admin_password" {
+  name         = "${var.vm_name}-azureuser-password"
+  value        = random_password.admin_password.result
+  key_vault_id = var.key_vault_id
+}
+
+#write logstash keystore secret to keyvault
+resource "azurerm_key_vault_secret" "keystore_password" {
+  name         = "${var.vm_name}-keystore-password"
+  value        = random_password.keystore_password.result
+  key_vault_id = var.key_vault_id
+}
+
+#############################################################################################
+# Telemetry Section - Toggled on and off with the telemetry variable
+# This allows us to get deployment frequency statistics for deployments
+# Re-using parts of the Core Enterprise Landing Zone methodology
+#############################################################################################
+locals {
+  #create an empty ARM template to use for generating the deployment value
+  telem_arm_subscription_template_content = <<TEMPLATE
+    {
+      "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+      "contentVersion": "1.0.0.0",
+      "parameters": {},
+      "variables": {},
+      "resources": [],
+      "outputs": {
+        "telemetry": {
+          "type": "String",
+          "value": "For more information, see https://aka.ms/alz/tf/telemetry"
+        }
+      }
+    }
+    TEMPLATE
+  module_identifier                       = lower("avs_log_filtering_vm")
+  telem_arm_deployment_name               = "${lower(var.guid_telemetry)}.${substr(local.module_identifier, 0, 20)}.${random_string.telemetry.result}"
+}
+
+#create a random string for uniqueness  
+resource "random_string" "telemetry" {
+  length  = 4
+  special = false
+  upper   = false
+  lower   = true
+}
+
+resource "azurerm_subscription_template_deployment" "telemetry_core" {
+  count = var.module_telemetry_enabled ? 1 : 0
+
+  name             = local.telem_arm_deployment_name
+  location         = var.rg_location
+  template_content = local.telem_arm_subscription_template_content
+}

--- a/terraform/modules/avs_log_filtering_vm/readme.md
+++ b/terraform/modules/avs_log_filtering_vm/readme.md
@@ -1,0 +1,8 @@
+### General 
+
+* Description: This module creates a virtual machine and configures it to use logstash to perform custom filtering of AVS syslogs.
+
+* The module leverages variables for naming and common values to be modified as part of the deployment.
+
+
+

--- a/terraform/modules/avs_log_filtering_vm/templates/configure_logstash.yaml
+++ b/terraform/modules/avs_log_filtering_vm/templates/configure_logstash.yaml
@@ -1,0 +1,32 @@
+#cloud-config
+runcmd:
+  - wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo gpg --dearmor -o /usr/share/keyrings/elastic-keyring.gpg
+  - sudo apt-get install apt-transport-https
+  - echo "deb [signed-by=/usr/share/keyrings/elastic-keyring.gpg] https://artifacts.elastic.co/packages/8.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-8.x.list
+  - apt-get update && apt-get install logstash
+  - /usr/share/logstash/bin/logstash-plugin install logstash-input-azure_event_hubs
+  - /usr/share/logstash/bin/logstash-plugin install microsoft-sentinel-logstash-output-plugin
+  - mkdir /usr/share/logstash/config
+  - mkdir /etc/sysconfig
+  - echo LOGSTASH_KEYSTORE_PASS=${logstashKeyStorePassword} > /etc/sysconfig/logstash
+  - chmod 600 /etc/sysconfig/logstash 
+  - export LOGSTASH_KEYSTORE_PASS=${logstashKeyStorePassword}
+  - /usr/share/logstash/bin/logstash-keystore create --path.settings /etc/logstash
+  - echo "${eventHubConnectionString}" | /usr/share/logstash/bin/logstash-keystore add eventhubconnectionstring --path.settings /etc/logstash
+  - echo "${eventHubConsumerGroupName}" | /usr/share/logstash/bin/logstash-keystore add eventhubconsumergroupname --path.settings /etc/logstash
+  - echo "${eventHubInputStorageAccountConnectionString}" | /usr/share/logstash/bin/logstash-keystore add eventhubinputstorageaccountconnectionstring --path.settings /etc/logstash
+  - echo "${lawPluginAppId}" | /usr/share/logstash/bin/logstash-keystore add lawpluginappid --path.settings /etc/logstash
+  - echo "${lawPluginAppSecret}" | /usr/share/logstash/bin/logstash-keystore add lawpluginappsecret --path.settings /etc/logstash
+  - echo "${lawPluginTenantId}" | /usr/share/logstash/bin/logstash-keystore add lawplugintenantid --path.settings /etc/logstash
+  - echo "${lawPluginDataCollectionEndpointURI}" | /usr/share/logstash/bin/logstash-keystore add lawplugindatacollectionendpointuri --path.settings /etc/logstash
+  - echo "${lawPluginDcrImmutableId}" | /usr/share/logstash/bin/logstash-keystore add lawplugindcrimmutableid --path.settings /etc/logstash
+  - echo "${lawPluginDcrStreamName}" | /usr/share/logstash/bin/logstash-keystore add lawplugindcrstreamname --path.settings /etc/logstash
+  - curl -L https://raw.githubusercontent.com/jchancellor-ms/avs-terraform/main/modules/avs_log_filtering_vm/templates/logstash-avs-custom.conf > /etc/logstash/conf.d/logstash-avs-custom.conf
+  - |
+    sed -i -e "s/# pipeline.ecs_compatibility: v8/pipeline.ecs_compatibility: disabled/g" /etc/logstash/logstash.yml
+  - chmod 644 /etc/logstash/startup.options
+  - |
+    chown -R logstash:logstash /var/log/logstash
+  - chmod -R 755 /var/log/logstash
+  - systemctl enable logstash.service
+  - systemctl start logstash.service

--- a/terraform/modules/avs_log_filtering_vm/templates/logstash-avs-custom.conf
+++ b/terraform/modules/avs_log_filtering_vm/templates/logstash-avs-custom.conf
@@ -1,0 +1,53 @@
+input {
+    azure_event_hubs {
+        event_hub_connections => ["${eventhubconnectionstring}"]
+        threads => 16
+        decorate_events => true
+        consumer_group => "${eventhubconsumergroupname}"
+        storage_connection => "${eventhubinputstorageaccountconnectionstring}"
+    }
+}
+
+filter {
+    json {
+        source => "message"
+    }
+    split {
+        field => "[records]"
+    }
+    mutate {
+        remove_field => ["message"]
+    }
+    if [records][properties][severity] in ["info", "debug"] {
+            drop { }
+    }    
+    mutate {
+        add_field => {
+            "ResourceId" => "%{[records][resourceId]}"
+            "LogCreationTime" => "%{[records][time]}"
+            "TimeGenerated" => "%{[records][time]}"
+            "Severity" => "%{[records][properties][severity]}"
+            "Facility" => "%{[records][properties][facility]}"
+            "Message" => "%{[records][properties][message]}"            
+        }
+
+        remove_field => ["records","event", "@version","@timestamp"]
+    }
+}
+
+output {
+    microsoft-sentinel-logstash-output-plugin {
+      client_app_Id => "${lawpluginappid}"
+      client_app_secret => "${lawpluginappsecret}"
+      tenant_id => "${lawplugintenantid}"
+      data_collection_endpoint => "${lawplugindatacollectionendpointuri}"
+      dcr_immutable_id => "${lawplugindcrimmutableid}"
+      dcr_stream_name => "${lawplugindcrstreamname}"
+      create_sample_file => false #must be false to send data to Log Analytics, set to true for testing
+      sample_file_path => "/tmp" #file location where a sample file will be written if create_sample_file is true
+    }
+
+    #stdout {} #uncomment this for testing
+}
+
+

--- a/terraform/modules/avs_log_filtering_vm/variables.tf
+++ b/terraform/modules/avs_log_filtering_vm/variables.tf
@@ -1,0 +1,54 @@
+variable "rg_name" {
+  type        = string
+  description = "The azure resource name for the resource group"
+}
+
+variable "rg_location" {
+  description = "Resource Group region location"
+  default     = "westus2"
+}
+
+variable "vm_name" {
+  type        = string
+  description = "Name of the vm being configured"
+}
+
+variable "vm_sku" {
+  type        = string
+  description = "sku of the vm being deployed"
+}
+
+variable "logstash_subnet_id" {
+  type        = string
+  description = "resource id of the logstash subnet"
+}
+
+variable "logstash_values" {
+  description = "Logstash configuration values for the deployment"
+  sensitive   = true
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "List of the tags that will be assigned to each resource"
+}
+
+variable "key_vault_id" {
+  type        = string
+  description = "azure resource id for the keyvault used to store logstash vm passwords"
+}
+
+#################################################################
+# telemetry variables
+#################################################################
+variable "module_telemetry_enabled" {
+  type        = bool
+  description = "toggle the telemetry on/off for this module"
+  default     = true
+}
+
+variable "guid_telemetry" {
+  type        = string
+  description = "guid used for telemetry identification. Defaults to module guid, but overrides with root if needed."
+  default     = "0f9a8adc-9d37-40b3-aaed-ab34b95cf6dd"
+}

--- a/terraform/modules/avs_test_deploy_logstash_syslog_filter/main.tf
+++ b/terraform/modules/avs_test_deploy_logstash_syslog_filter/main.tf
@@ -1,0 +1,152 @@
+#create the resource group for all of the log processing items
+resource "azurerm_resource_group" "avs_log_processing" {
+  name     = var.rg_name
+  location = var.rg_location
+}
+
+#create the event hub artifacts
+module "create_event_hub_resources" {
+  source = "../../modules/avs_event_hub_for_logs"
+
+  rg_name                                     = azurerm_resource_group.avs_log_processing.name
+  rg_location                                 = azurerm_resource_group.avs_log_processing.location
+  eventhub_namespace_name                     = var.eventhub_namespace_name
+  eventhub_capacity                           = var.eventhub_capacity
+  eventhub_name                               = var.eventhub_name
+  eventhub_partition_count                    = var.eventhub_partition_count
+  eventhub_message_retention_days             = var.eventhub_message_retention_days
+  diagnostic_eventhub_authorization_rule_name = var.diagnostic_eventhub_authorization_rule_name
+  logstash_eventhub_authorization_rule_name   = var.logstash_eventhub_authorization_rule_name
+  consumer_group_name                         = var.consumer_group_name
+  plugin_storage_account_name                 = var.plugin_storage_account_name
+  tags                                        = var.tags
+}
+
+#create a logging application and service principal
+module "create_logging_service_principal" {
+  source                                    = "../../modules/avs_log_filtering_accounts"
+  avs_log_processing_service_principal_name = var.avs_log_processing_service_principal_name
+}
+
+#create the log analytics workspace, dCE and DCR resources
+module "create_log_analytics_resources" {
+  source = "../../modules/avs_log_analytics_w_custom_syslog"
+
+  rg_name                            = azurerm_resource_group.avs_log_processing.name
+  rg_location                        = azurerm_resource_group.avs_log_processing.location
+  tags                               = var.tags
+  log_analytics_name                 = var.log_analytics_name
+  custom_table_name                  = var.custom_table_name
+  data_collection_endpoint_name      = var.data_collection_endpoint_name
+  data_collection_rule_name          = var.data_collection_rule_name
+  log_processing_principal_object_id = module.create_logging_service_principal.logging_object_id
+}
+
+#create a keyvault and access policy
+#deploy the key vault for the jump host
+data "azuread_client_config" "current" {}
+
+module "avs_keyvault_with_access_policy" {
+  source = "../../modules/avs_key_vault"
+
+  #values to create the keyvault
+  rg_name                   = azurerm_resource_group.avs_log_processing.name
+  rg_location               = azurerm_resource_group.avs_log_processing.location
+  keyvault_name             = var.keyvault_name
+  azure_ad_tenant_id        = data.azuread_client_config.current.tenant_id
+  deployment_user_object_id = data.azuread_client_config.current.object_id
+  tags                      = var.tags
+}
+
+#create the logstash vms and use cloud-init to install and configure logstash
+module "avs_logstash_vms" {
+  source   = "../../modules/avs_log_filtering_vm"
+  for_each = { for vm in var.logstash_vms : vm.vm_name => vm }
+
+  rg_name            = azurerm_resource_group.avs_log_processing.name
+  rg_location        = azurerm_resource_group.avs_log_processing.location
+  tags               = var.tags
+  vm_name            = each.value.vm_name
+  vm_sku             = each.value.vm_sku
+  logstash_subnet_id = var.logstash_subnet_id
+  key_vault_id       = module.avs_keyvault_with_access_policy.keyvault_id
+
+  logstash_values = {
+    eventHubConnectionString                    = module.create_event_hub_resources.event_hub_connection_string
+    eventHubConsumerGroupName                   = module.create_event_hub_resources.event_hub_consumer_group_name
+    eventHubInputStorageAccountConnectionString = module.create_event_hub_resources.event_hub_storage_account_name
+    lawPluginAppId                              = module.create_logging_service_principal.logging_application_id
+    lawPluginAppSecret                          = module.create_logging_service_principal.logging_application_secret
+    lawPluginTenantId                           = data.azuread_client_config.current.tenant_id
+    lawPluginDataCollectionEndpointURI          = module.create_log_analytics_resources.logs_ingestion_endpoint
+    lawPluginDcrImmutableId                     = module.create_log_analytics_resources.dcr_immutable_id
+    lawPluginDcrStreamName                      = module.create_log_analytics_resources.dcr_stream_name
+  }
+
+  depends_on = [
+    module.avs_keyvault_with_access_policy
+  ]
+}
+
+
+#######################################################################################################################
+# Configure a diagnostic setting on the private cloud to send the syslog data to the event hub
+#######################################################################################################################
+
+resource "azurerm_monitor_diagnostic_setting" "private_cloud_syslog" {
+  name                           = var.diagnostics_setting_name
+  target_resource_id             = var.private_cloud_resource_id
+  eventhub_name                  = module.create_event_hub_resources.event_hub_name
+  eventhub_authorization_rule_id = module.create_event_hub_resources.event_hub_authorization_rule_id
+
+  enabled_log {
+    category = "VMwareSyslog"
+
+    retention_policy {
+      enabled = false
+    }
+  }
+}
+
+
+#############################################################################################
+# Telemetry Section - Toggled on and off with the telemetry variable
+# This allows us to get deployment frequency statistics for deployments
+# Re-using parts of the Core Enterprise Landing Zone methodology
+#############################################################################################
+locals {
+  #create an empty ARM template to use for generating the deployment value
+  telem_arm_subscription_template_content = <<TEMPLATE
+    {
+      "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+      "contentVersion": "1.0.0.0",
+      "parameters": {},
+      "variables": {},
+      "resources": [],
+      "outputs": {
+        "telemetry": {
+          "type": "String",
+          "value": "For more information, see https://aka.ms/alz/tf/telemetry"
+        }
+      }
+    }
+    TEMPLATE
+  module_identifier                       = lower("avs_test_deploy_logstash_syslog_filter")
+  telem_arm_deployment_name               = "${lower(var.guid_telemetry)}.${substr(local.module_identifier, 0, 20)}.${random_string.telemetry.result}"
+}
+
+#create a random string for uniqueness  
+resource "random_string" "telemetry" {
+  length  = 4
+  special = false
+  upper   = false
+  lower   = true
+}
+
+resource "azurerm_subscription_template_deployment" "telemetry_core" {
+  count = var.module_telemetry_enabled ? 1 : 0
+
+  name             = local.telem_arm_deployment_name
+  location         = var.rg_location
+  template_content = local.telem_arm_subscription_template_content
+}

--- a/terraform/modules/avs_test_deploy_logstash_syslog_filter/providers.tf
+++ b/terraform/modules/avs_test_deploy_logstash_syslog_filter/providers.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~>3.00"
+    }
+    azapi = {
+      source = "azure/azapi"
+    }
+  }
+
+/* uncomment this if using a storage backend
+  backend "azurerm" {
+    resource_group_name  = "<storage account resource group>"
+    storage_account_name = "<storage account name>"
+    container_name       = "<state blob container name>"
+    key                  = "<state blob file name>"
+    use_azuread_auth     = true
+    subscription_id      = "<subscription id for the storage account>"
+    tenant_id            = "<tenant id for the storage account>"
+  }
+*/
+}
+
+provider "azapi" {
+}
+
+provider "azuread" {
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/terraform/modules/avs_test_deploy_logstash_syslog_filter/readme.md
+++ b/terraform/modules/avs_test_deploy_logstash_syslog_filter/readme.md
@@ -1,0 +1,40 @@
+# Deploy a Photon test VM to a new DHCP enabled T1 and network segment
+
+## Table of contents
+
+- [Sample Details](#sample-details)
+- [Sample Implementation - Automation Options](#automation-implementation)
+- [Appendix](#appendix)
+
+
+## Sample Details
+
+This sample demonstrates the configuration and use of a module that enables custom filtering of the syslog data prior to ingesting it into a log analytics workspace. It takes as input naming and tag information as well as the resource ID's for the private cloud being monitored as well as the subnet where the logstash VM's will be deployed. The module creates the following resources:
+
+| Resource       | Usage                                                 |
+| ------------------- | ------------------------------------------------------------ |
+| Resource Group           | Resource container for the log filter related resources |
+| Event Hub Related Resources | An Event Hub Namespace with an Event Hub, Consumer Group, Authorization Rules, and a storage account for use by the logstash event hub plugin |
+| Azure Monitor Related Resources | A Log Analytics Workspace, Data Collection Endpoint, and Data Collection Rules configured to use a custom table |
+| Service Principal related artifacts | An Azure AD application, Service Principal and associated secrets
+| Logstash related resources | Two Ubuntu 20.04 VM's, a key vault for storing the vm related secrets, and a set of templates for configuring logstash |
+| Private Cloud configuration | A diagnostic setting on the private cloud the configures the syslog to go the eventhub for processing |
+
+The overall architecture is rather simple.  The private cloud sends the full syslog to an Event Hub.  A pair of VM's are configured to run logstash as a service and the terraform leverages a cloud-init template file to install and configure logstash.  Logstash uses an input plugin for EventHub to connect to the event hub and get the eventhub data.  From there a series of json and mutate filters are used to drop info level logs from the input stream.  It then uses the Sentinel plugin to send the data to a custom log analytics table in a new log analytics workspace. The eventhub plugin uses a storage account as a witness which allows for multiple processing VM's to share the workload and provide redundancy.
+
+[(Back to top)](#table-of-contents)
+
+## Automation implementation
+
+This sample is a root module that calls several child modules included in the modules and scenarios subdirectories of the terraform directory.  This root module inputs the deployed values directly in the submodule calls, so to change the deployment behavior, modify the values directly in the main.tf file. This module also includes a sample providers file that can be modified to fit your specific environment.
+
+To deploy this module, ensure you have a deployment machine that meets the pre-requisites for Azure Deployments with terraform. Clone this repo to a local directory on the deployment machine.  Update the sample_config.auto.tfvars variable values and make any updates to the providers sample file backend block and uncomment them if needed.
+
+Execute the terraform init/plan/apply workflow to execute the deployment.
+
+[(Back to top)](#table-of-contents)
+
+## Appendix
+
+
+[(Back to top)](#table-of-contents)

--- a/terraform/modules/avs_test_deploy_logstash_syslog_filter/sample_config.auto.tfvars
+++ b/terraform/modules/avs_test_deploy_logstash_syslog_filter/sample_config.auto.tfvars
@@ -1,0 +1,37 @@
+rg_name                                     = "AvsLogFilterExample"
+rg_location                                 = "Canada Central"
+avs_log_processing_service_principal_name   = "AvsLogFilterSP"
+eventhub_namespace_name                     = "avslogfilterehnamespace"
+eventhub_capacity                           = 4
+eventhub_name                               = "avslogfiltereh"
+eventhub_partition_count                    = 2
+eventhub_message_retention_days             = 3
+diagnostic_eventhub_authorization_rule_name = "diagnosticSettingAuthRule"
+logstash_eventhub_authorization_rule_name   = "logstashAuthRule"
+consumer_group_name                         = "logstashConsumerGroup"
+plugin_storage_account_name                 = "avslogfilterstgacct"
+log_analytics_name                          = "avsLogAnalyticsWorkspace"
+custom_table_name                           = "CustomAVSFilteredSyslog_CL"
+data_collection_endpoint_name               = "AvsLogFilterDataCollectionEndpoint"
+data_collection_rule_name                   = "AvsLogFilterDataCollectionRule"
+diagnostics_setting_name                    = "AVSEventHubLogAnalytics"
+private_cloud_resource_id                   = "<resourceID of the private cloud being monitored>"
+logstash_subnet_id                          = "<resourceId of the subnet for the logstash processing vm>"
+keyvault_name                               = "avslogkeyvault"
+
+tags = {
+  environment = "Dev"
+  CreatedBy   = "Terraform"
+}
+
+logstash_vms = [
+  {
+    vm_name = "logstashvm1",
+    vm_sku  = "Standard_E2as_v5"
+  },
+  {
+    vm_name = "logstashvm2",
+    vm_sku  = "Standard_E2as_v5"
+  },
+]
+

--- a/terraform/modules/avs_test_deploy_logstash_syslog_filter/variables.tf
+++ b/terraform/modules/avs_test_deploy_logstash_syslog_filter/variables.tf
@@ -1,0 +1,127 @@
+variable "rg_name" {
+  type        = string
+  description = "The azure resource name for the resource group"
+}
+
+variable "rg_location" {
+  description = "Resource Group region location"
+  default     = "westus2"
+}
+
+
+variable "avs_log_processing_service_principal_name" {
+  type        = string
+  description = "The name used for the log processing service principal"
+}
+
+variable "eventhub_namespace_name" {
+  type        = string
+  description = "The name for the eventhub namespace"
+}
+
+variable "eventhub_capacity" {
+  type        = number
+  description = "The number of eventhub capacity units on the namespace"
+  default     = 8
+}
+
+variable "eventhub_name" {
+  type        = string
+  description = "The name of the eventhub where the logs are being sent"
+}
+
+variable "eventhub_partition_count" {
+  type        = number
+  description = "The number of partitions for the eventhub"
+  default     = 2
+}
+
+variable "eventhub_message_retention_days" {
+  type        = number
+  description = "The number of days for message retention"
+  default     = 3
+}
+
+variable "diagnostic_eventhub_authorization_rule_name" {
+  type        = string
+  description = "Name for the authorization rule used by the eventhub diagnostic setting"
+}
+
+variable "logstash_eventhub_authorization_rule_name" {
+  type        = string
+  description = "Name for the authorization rule used by the logstash event hub plugin"
+}
+
+variable "consumer_group_name" {
+  type        = string
+  description = "The consumer group name for the event hub plugin to process the logs."
+}
+
+variable "plugin_storage_account_name" {
+  type        = string
+  description = "The storage account name for the storage account used by the logstash event hub plugin as a witness."
+}
+
+variable "log_analytics_name" {
+  type        = string
+  description = "The name of the log analytics workspace that will receive the syslogs"
+}
+
+variable "custom_table_name" {
+  type        = string
+  description = "The name for the custom table that will hold the syslogs"
+}
+
+variable "data_collection_endpoint_name" {
+  type        = string
+  description = "The name for the data collection endpoint that the logstash log analytics plugin uses"
+}
+
+variable "data_collection_rule_name" {
+  type        = string
+  description = "Name of the data collection rule used by the logstash log analytics plugin"
+}
+
+variable "diagnostics_setting_name" {
+  type        = string
+  description = "The name for the diagnostics setting configured on the private cloud to send logs to the event hub"
+}
+
+variable "private_cloud_resource_id" {
+  type        = string
+  description = "The full resource ID for the private cloud where the diagnostic setting is being configured"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "List of the tags that will be assigned to each resource"
+}
+
+variable "logstash_subnet_id" {
+  type        = string
+  description = "full resource id of the subnet where the logstash vm's will be deployed"
+}
+
+variable "logstash_vms" {
+  description = "list of vm values to create one or more logstash vm's"
+}
+
+variable "keyvault_name" {
+  type        = string
+  description = "name for the keyvault used to store the logstash vm login passwords"
+}
+
+#################################################################
+# telemetry variables
+#################################################################
+variable "module_telemetry_enabled" {
+  type        = bool
+  description = "toggle the telemetry on/off for this module"
+  default     = true
+}
+
+variable "guid_telemetry" {
+  type        = string
+  description = "guid used for telemetry identification. Defaults to module guid, but overrides with root if needed."
+  default     = "0f9a8adc-9d37-40b3-aaed-ab34b95cf6dd"
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

This pull request adds 5 new terraform modules that are used to create a custom syslog filtering solution for AVS.  Details can be found in the readme file for the avs_test_deploy_logstash_syslog_filter module.

## This PR fixes/adds/changes/removes

1. Adds a module that leverages VM's running logstash to filter the AVS syslog to reduce log ingestion volume into a workspace.


### Breaking Changes



## Testing Evidence
![image](https://github.com/Azure/Enterprise-Scale-for-AVS/assets/84210452/4b042c0f-2819-4172-85a8-c3879b3c4d23)
![image](https://github.com/Azure/Enterprise-Scale-for-AVS/assets/84210452/1652a629-a712-4849-a97b-50fcc8a472ec)



## As part of this Pull Request I have

- [x ] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale-for-AVS/pulls)
- [x ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale-for-AVS/tree/main)
- [ x] Performed testing and provided evidence.
- [ x] Updated relevant and associated documentation.
