### PR TITLE
Enhance Service Health Alert testing and recommendations

### DIFF
--- a/BrownField/Auto-assessment/scripts/All-Recommendations.ps1
+++ b/BrownField/Auto-assessment/scripts/All-Recommendations.ps1
@@ -604,3 +604,39 @@ function New-NoAutomatedDeployment-Recommendation {
         -LinkUrl "https://learn.microsoft.com/azure/cloud-adoption-framework/scenarios/azure-vmware/eslz-platform-automation-and-devops" `
         -Priority "Medium"
 }
+
+function New-NoServiveHealthAlert-Recommendation {
+    param(
+        [string]$sddcName
+    )
+    
+    return New-Recommendation -Category "Management" `
+        -Observation "SDDC '$sddcName' has no Service Health Alert configured." `
+        -Recommendation "Ensure that Service Health Alert is configured for SDDC for monitoring." `
+        -LinkUrl "https://learn.microsoft.com/azure/cloud-adoption-framework/scenarios/azure-vmware/eslz-management-and-monitoring" `
+        -Priority "High"
+}
+
+function New-DisabledServiveHealthAlert-Recommendation {
+    param(
+        [string]$sddcName
+    )
+    
+    return New-Recommendation -Category "Management" `
+        -Observation "SDDC '$sddcName' has at least one disabled Service Health Alert." `
+        -Recommendation "Ensure that Service Health Alert is enabled for SDDC for monitoring." `
+        -LinkUrl "https://learn.microsoft.com/azure/cloud-adoption-framework/scenarios/azure-vmware/eslz-management-and-monitoring" `
+        -Priority "High"
+}
+
+function New-NoRecipientForServiveHealthAlert-Recommendation {
+    param(
+        [string]$sddcName
+    )
+    
+    return New-Recommendation -Category "Management" `
+        -Observation "SDDC '$sddcName' has at least one Service Health Alert with no recipient." `
+        -Recommendation "Ensure that Service Health Alert has recipient for notification on SDDC for monitoring." `
+        -LinkUrl "https://learn.microsoft.com/azure/cloud-adoption-framework/scenarios/azure-vmware/eslz-management-and-monitoring" `
+        -Priority "High"
+}

--- a/BrownField/Auto-assessment/scripts/All-Recommendations.ps1
+++ b/BrownField/Auto-assessment/scripts/All-Recommendations.ps1
@@ -640,3 +640,27 @@ function New-NoRecipientForServiveHealthAlert-Recommendation {
         -LinkUrl "https://learn.microsoft.com/azure/cloud-adoption-framework/scenarios/azure-vmware/eslz-management-and-monitoring" `
         -Priority "High"
 }
+
+function New-ClusterCountNearLimit-Recommendation {
+    param(
+        [string]$sddcName
+    )
+    
+    return New-Recommendation -Category "Management" `
+        -Observation "SDDC '$sddcName' has cluster count near the limit of 16." `
+        -Recommendation "Ensure that cluster count is within the limit of 16 for SDDC." `
+        -LinkUrl "https://learn.microsoft.com/azure/cloud-adoption-framework/scenarios/azure-vmware/eslz-management-and-monitoring" `
+        -Priority "Medium"
+}
+
+function New-NodeCountNearLimit-Recommendation {
+    param(
+        [string]$sddcName
+    )
+    
+    return New-Recommendation -Category "Management" `
+        -Observation "SDDC '$sddcName' has node count nearing the limit of 96." `
+        -Recommendation "Ensure that node count is within the limit of 96 for SDDC." `
+        -LinkUrl "https://learn.microsoft.com/azure/cloud-adoption-framework/scenarios/azure-vmware/eslz-management-and-monitoring" `
+        -Priority "Medium"
+}

--- a/BrownField/Auto-assessment/scripts/Get-Recommendation.ps1
+++ b/BrownField/Auto-assessment/scripts/Get-Recommendation.ps1
@@ -60,6 +60,9 @@ function Get-Recommendation {
         "LowUtilizationforvWANERGateway" { return New-LowUtilizationforvWANERGateway-Recommendation -sddcName $sddcName }
         "NoResourceLock" { return New-NoResourceLock-Recommendation -sddcName $sddcName }
         "NoAutomatedDeployment" { return New-NoAutomatedDeployment-Recommendation -sddcName $sddcName }
+        "NoServiveHealthAlert" { return New-NoServiveHealthAlert-Recommendation -sddcName $sddcName }
+        "DisabledServiveHealthAlert" { return New-DisabledServiveHealthAlert-Recommendation -sddcName $sddcName }
+        "NoRecipientForServiveHealthAlert" { return New-NoRecipientForServiveHealthAlert-Recommendation -sddcName $sddcName }
         default { throw "Unknown recommendation type: $type" }
     }
 }

--- a/BrownField/Auto-assessment/scripts/Get-Recommendation.ps1
+++ b/BrownField/Auto-assessment/scripts/Get-Recommendation.ps1
@@ -63,6 +63,8 @@ function Get-Recommendation {
         "NoServiveHealthAlert" { return New-NoServiveHealthAlert-Recommendation -sddcName $sddcName }
         "DisabledServiveHealthAlert" { return New-DisabledServiveHealthAlert-Recommendation -sddcName $sddcName }
         "NoRecipientForServiveHealthAlert" { return New-NoRecipientForServiveHealthAlert-Recommendation -sddcName $sddcName }
+        "ClusterCountNearLimit" { return New-ClusterCountNearLimit-Recommendation -sddcName $sddcName }
+        "NodeCountNearLimit" { return New-NodeCountNearLimit-Recommendation -sddcName $sddcName }
         default { throw "Unknown recommendation type: $type" }
     }
 }

--- a/BrownField/Auto-assessment/scripts/Main.ps1
+++ b/BrownField/Auto-assessment/scripts/Main.ps1
@@ -8,15 +8,15 @@
 function Main {
     try {
         
-        $tenantId = "27eda52d-06a5-4e9f-bd76-1a062e47aba0"
-        $subscriptionId = "d52f9c4a-5468-47ec-9641-da4ef1916bb5"
+        $tenantId = ""
+        $subscriptionId = ""
         
         # Provide the names of the SDDCs to test
         # If the array is empty, all SDDCs in the subscriptio will be tested
         # Example: $namesofSddcsToTest = @()
         # If you want to test specific SDDCs, provide the names in comma-separated format
         # Example: $namesofSddcsToTest = @("prod-sddc", "uat-sddc")
-        $namesofSddcsToTest = @("sreeni-sddc")
+        $namesofSddcsToTest = @()
 
         # Provide the design areas to test
         # If the array is empty, all design areas will be tested
@@ -24,7 +24,7 @@ function Main {
         # If you want to test specific design areas, provide the names in comma-separated format
         # Example: $designAreasToTest = @("Security", "Networking")
         # Possible values: "Identity", "Networking", "Security", "Management", "BCDR", "Automation"
-        $designAreasToTest = @("Management")
+        $designAreasToTest = @()
 
         # Initialize the recommendations array. Leave this as is.
         $Global:recommendations = @()

--- a/BrownField/Auto-assessment/scripts/Main.ps1
+++ b/BrownField/Auto-assessment/scripts/Main.ps1
@@ -8,15 +8,15 @@
 function Main {
     try {
         
-        $tenantId = "<CHANGE-ME>"
-        $subscriptionId = "<CHANGE-ME>"
+        $tenantId = "27eda52d-06a5-4e9f-bd76-1a062e47aba0"
+        $subscriptionId = "d52f9c4a-5468-47ec-9641-da4ef1916bb5"
         
         # Provide the names of the SDDCs to test
         # If the array is empty, all SDDCs in the subscriptio will be tested
         # Example: $namesofSddcsToTest = @()
         # If you want to test specific SDDCs, provide the names in comma-separated format
         # Example: $namesofSddcsToTest = @("prod-sddc", "uat-sddc")
-        $namesofSddcsToTest = @()
+        $namesofSddcsToTest = @("sreeni-sddc")
 
         # Provide the design areas to test
         # If the array is empty, all design areas will be tested
@@ -24,7 +24,7 @@ function Main {
         # If you want to test specific design areas, provide the names in comma-separated format
         # Example: $designAreasToTest = @("Security", "Networking")
         # Possible values: "Identity", "Networking", "Security", "Management", "BCDR", "Automation"
-        $designAreasToTest = @()
+        $designAreasToTest = @("Management")
 
         # Initialize the recommendations array. Leave this as is.
         $Global:recommendations = @()

--- a/BrownField/Auto-assessment/scripts/Recommendations.csv
+++ b/BrownField/Auto-assessment/scripts/Recommendations.csv
@@ -1,0 +1,2 @@
+"Category","Priority","Observation","Recommendation","LinkText","LinkUrl"
+"Management","High","AVS Syslog Diagnostic setting is not configured for SDDC 'sreeni-sddc'.","Configure AVS Syslog Diagnostic setting for SDDC for monitoring and troubleshooting.","","https://learn.microsoft.com/azure/cloud-adoption-framework/scenarios/azure-vmware/eslz-management-and-monitoring"

--- a/BrownField/Auto-assessment/scripts/Test-All-DesignAreas.ps1
+++ b/BrownField/Auto-assessment/scripts/Test-All-DesignAreas.ps1
@@ -26,6 +26,7 @@
 . ./Test-SRM.ps1
 . ./Test-Resource-Lock.ps1
 . ./Test-Deployment.ps1
+. ./Test-ClusterNode-Size.ps1
 function Test-All-DesignAreas {
     param (
         [SecureString]$token,
@@ -113,9 +114,17 @@ function Test-All-DesignAreas {
         Write-Host "Testing Azure Role Based Access Control"
         Test-AccessControl -token $token -sddc $sddc
 
-        # Test Alerts
-        Write-Host "Testing Alerts"
+        # Test Metric Alerts
+        Write-Host "Testing Metric Alerts"
         Test-Alerts -token $token -sddc $sddc
+
+        # Test Service Health Alert
+        Write-Host "Testing Service Health Alert"
+        Test-ServiceHealth-Alert -token $token -sddc $sddc
+
+        # Test Cluster and Node Counts
+        Write-Host "Testing Cluster and Node Counts"
+        Test-ClusterNode-Size -token $token -sddc $sddc
 
         # Test Arc
         Write-Host "Testing Arc"

--- a/BrownField/Auto-assessment/scripts/Test-ClusterNode-Size.ps1
+++ b/BrownField/Auto-assessment/scripts/Test-ClusterNode-Size.ps1
@@ -1,0 +1,56 @@
+function Test-ClusterNode-Size {
+    param (
+        [SecureString]$token,
+        [PSCustomObject]$sddc
+    )
+    try {
+
+        # Get AVS SDDC details
+        $sddcDetails = Get-AVS-SDDC-Details -sddc $sddc
+
+        # Set the node and cluster count
+        $nodeCount = $sddc.properties.managementCluster.clusterSize
+        $clusterCount = 1
+
+        # Define API Endpoint
+        $apiUrl = [string]::Format(
+            "https://management.azure.com/subscriptions/{0}/resourceGroups/{1}/" +
+            "providers/Microsoft.AVS/privateClouds/{2}/clusters?api-version=2023-09-01"
+            ,
+            $sddcDetails.subscriptionId,
+            $sddcDetails.resourceGroupName,
+            $sddcDetails.sddcName
+        )
+
+        # Make the request
+        $response = Invoke-APIRequest `
+                        -method "Get" `
+                        -url $apiUrl `
+                        -token $token
+
+        # Process the response
+        if ($response -and $response.value -and $response.value.Count -gt 0) {
+            foreach ($cluster in $response.value) {
+                $clusterCount++
+                $nodeCount += $cluster.properties.clusterSize
+            }
+        }
+
+        # Check if the cluster count is above 14 and node count is above 90
+        $sizeRecommendations = @()
+        if ($clusterCount -gt 14) { $sizeRecommendations += "ClusterCountNearLimit" }
+        if ($nodeCount -gt 90) { $sizeRecommendations += "NodeCountNearLimit" }
+
+        # Add the recommendations
+        foreach ($recommendationType in $sizeRecommendations) {
+            if (![string]::IsNullOrEmpty($recommendationType)) {
+                $Global:recommendations += Get-Recommendation -type $recommendationType `
+                    -sddcName $sddc.name
+            }
+        }
+
+    }
+    catch {
+        Write-Error "Test Cluster Node Size Failed: $_"
+    }
+}

--- a/BrownField/Auto-assessment/scripts/Test-Management-DesignArea.ps1
+++ b/BrownField/Auto-assessment/scripts/Test-Management-DesignArea.ps1
@@ -2,6 +2,7 @@
 . ./Test-AVS-DiagSetting.ps1
 . ./Test-vSAN-StoragePolicy.ps1
 . ./Test-SRM.ps1
+. ./Test-ServiceHealthAlert.ps1
 function Test-Management-DesignArea {
     param (
         [SecureString]$token,
@@ -10,6 +11,10 @@ function Test-Management-DesignArea {
         [PSCustomObject]$sddc
     )
     try {
+        # Test Service Health Alert
+        Write-Host "Testing Service Health Alert"
+        Test-ServiceHealth-Alert -token $token -sddc $sddc
+
         # Test Content Library
         Write-Host "Testing Content Library Storage"
         Test-ContentLibrary -token $token -sddc $sddc

--- a/BrownField/Auto-assessment/scripts/Test-Management-DesignArea.ps1
+++ b/BrownField/Auto-assessment/scripts/Test-Management-DesignArea.ps1
@@ -2,7 +2,9 @@
 . ./Test-AVS-DiagSetting.ps1
 . ./Test-vSAN-StoragePolicy.ps1
 . ./Test-SRM.ps1
+. ./Test-Alerts.ps1
 . ./Test-ServiceHealthAlert.ps1
+. ./Test-ClusterNode-Size.ps1
 function Test-Management-DesignArea {
     param (
         [SecureString]$token,
@@ -11,6 +13,14 @@ function Test-Management-DesignArea {
         [PSCustomObject]$sddc
     )
     try {
+        # Test Cluster and Node Counts
+        Write-Host "Testing Cluster and Node Counts"
+        Test-ClusterNode-Size -token $token -sddc $sddc
+
+        # Test Metric Alerts
+        Write-Host "Testing Metric Alerts"
+        Test-Alerts -token $token -sddc $sddc
+
         # Test Service Health Alert
         Write-Host "Testing Service Health Alert"
         Test-ServiceHealth-Alert -token $token -sddc $sddc

--- a/BrownField/Auto-assessment/scripts/Test-ServiceHealthAlert.ps1
+++ b/BrownField/Auto-assessment/scripts/Test-ServiceHealthAlert.ps1
@@ -1,0 +1,66 @@
+function Test-ServiceHealth-Alert {
+    param (
+        [SecureString]$token,
+        [PSCustomObject]$sddc
+    )
+
+    try {
+
+        # Get AVS SDDC details
+        $sddcDetails = Get-AVS-SDDC-Details -sddc $sddc
+
+        # Define API Endpoint
+        $apiUrl = [string]::Format(
+            "https://management.azure.com/subscriptions/{0}/resourceGroups/{1}/" +
+            "providers/Microsoft.Insights/activityLogAlerts?api-version=2020-10-01"
+            ,
+            $sddcDetails.subscriptionId,
+            $sddcDetails.resourceGroupName
+        )
+
+        # Make the request
+        $response = Invoke-APIRequest `
+                        -method "Get" `
+                        -url $apiUrl `
+                        -token $token
+
+        # Process the response
+        if ($response -and $response.value -and $response.value.Count -gt 0) {
+            $alerts = $response.value | Where-Object { $_.properties.scopes -contains $scope }
+            if ($alerts) {
+                foreach ($alert in $alerts) {
+                    if (-not $alert.properties.enabled) {
+                        $metricRecommendations += "DisabledAlert"
+                    }
+                    if (-not $alert.properties.actions) {
+                        $metricRecommendations += "NoRecipientForAlert"
+                    }
+                    foreach ($criteria in $alert.properties.criteria?.allOf) {
+                        if ($criteria.metricName -in $metricsToTrack) {
+                        $metricsBeingTracked += $criteria.metricName
+                        }
+                    }
+                }
+                if ($metricsBeingTracked.Count -ne $metricsToTrack.Count) {
+                    $metricRecommendations += "MissingAlerts"
+                }
+            }else {
+                $metricRecommendations += "NoAlerts"
+            }
+        }
+        else {
+            $metricRecommendations += "NoAlerts"
+        }
+
+        # Add the recommendation
+        foreach ($recommendationType in $metricRecommendations | Select-Object -Unique) {
+            if (![string]::IsNullOrEmpty($recommendationType)) {
+                $Global:recommendations += Get-Recommendation -type $recommendationType `
+                    -sddcName $sddc.name
+            }
+        }
+    }
+    catch {
+        Write-Error "Alerts Test failed: $_"
+    }
+}

--- a/BrownField/Auto-assessment/scripts/Test-ServiceHealthAlert.ps1
+++ b/BrownField/Auto-assessment/scripts/Test-ServiceHealthAlert.ps1
@@ -9,6 +9,10 @@ function Test-ServiceHealth-Alert {
         # Get AVS SDDC details
         $sddcDetails = Get-AVS-SDDC-Details -sddc $sddc
 
+        # Define scope
+        $scope = "/subscriptions/$($sddcDetails.subscriptionId)/resourceGroups/$($sddcDetails.resourceGroupName)/providers/Microsoft.AVS/privateClouds/$($sddcDetails.sddcName)"
+
+
         # Define API Endpoint
         $apiUrl = [string]::Format(
             "https://management.azure.com/subscriptions/{0}/resourceGroups/{1}/" +
@@ -26,9 +30,9 @@ function Test-ServiceHealth-Alert {
 
         # Process the response
         if ($response -and $response.value -and $response.value.Count -gt 0) {
-            $alerts = $response.value | Where-Object { $_.properties.scopes -contains $scope }
-            if ($alerts) {
-                foreach ($alert in $alerts) {
+            $conditions = $response.value | Where-Object { $_.properties.condition.allOf.anyOf.field -contains $scope }
+            if ($conditions) {
+                foreach ($condition in $conditions) {
                     if (-not $alert.properties.enabled) {
                         $metricRecommendations += "DisabledAlert"
                     }

--- a/BrownField/Auto-assessment/scripts/Test-ServiceHealthAlert.ps1
+++ b/BrownField/Auto-assessment/scripts/Test-ServiceHealthAlert.ps1
@@ -32,10 +32,10 @@ function Test-ServiceHealth-Alert {
         if ($response -and $response.value -and $response.value.Count -gt 0) {
             foreach ($alert in $response.value) {
                 if ($alert.properties.enabled -eq $false) {
-                    $metricRecommendations += "DisabledServiveHealthAlert"
+                    $alertRecommendations += "DisabledServiveHealthAlert"
                 }
                 if ($alert.properties.actions.actionGroups.Count -eq 0) {
-                    $metricRecommendations += "NoRecipientForServiveHealthAlert"
+                    $alertRecommendations += "NoRecipientForServiveHealthAlert"
                 }
                 $conditions = $alert.properties.condition.allOf
                 if ($conditions) {
@@ -50,17 +50,17 @@ function Test-ServiceHealth-Alert {
                         }
                     }
                 }else {
-                    $metricRecommendations += "NoServiveHealthAlert"
+                    $alertRecommendations += "NoServiveHealthAlert"
                 }
             }
             
         }
         else {
-            $metricRecommendations += "NoServiveHealthAlert"
+            $alertRecommendations += "NoServiveHealthAlert"
         }
 
         # Add the recommendation
-        foreach ($recommendationType in $metricRecommendations | Select-Object -Unique) {
+        foreach ($recommendationType in $alertRecommendations | Select-Object -Unique) {
             if (![string]::IsNullOrEmpty($recommendationType)) {
                 $Global:recommendations += Get-Recommendation -type $recommendationType `
                     -sddcName $sddc.name


### PR DESCRIPTION
Improve Service Health Alert scripts by adding testing logic, defining scope and filter conditions, and incorporating recommendations. Remove hardcoded tenant and subscription IDs for better configuration flexibility.