### PR TITLE
Clarify behavior with dummy AVS guest VM credentials

### DIFF
--- a/BrownField/Auto-assessment/run.md
+++ b/BrownField/Auto-assessment/run.md
@@ -39,7 +39,7 @@ cd BrownField\Auto-assessment\scripts
 
     ![Select Account](./media/account.png)
 
-* If assessment is run for `Security` or `all` desgin areas then another prompt asking for AVS guest VM credentials is displayed. These credentials are used for tests like validating if a VM is domain joined or not.
+* If assessment is run for `Security` or `all` desgin areas then another prompt asking for AVS guest VM credentials is displayed. These credentials are used for tests like validating if a VM is domain joined or not. If fake/dummy credentials are provided, these tests will be skipped.
 
     ![AVS guest VM Credential Prompt](./media/guestVMcreds.png)
 


### PR DESCRIPTION
Update documentation to specify that providing fake/dummy AVS guest VM credentials will skip certain tests during the assessment process.