### PR TITLE
Changing Alert Name that was duplicated on Portal Deployment

### DIFF
--- a/AVS-Landing-Zone/GreenField/PortalUI/ARM/ESLZDeploy.deploy.json
+++ b/AVS-Landing-Zone/GreenField/PortalUI/ARM/ESLZDeploy.deploy.json
@@ -1947,8 +1947,8 @@
                         "Severity": 2
                       },
                       {
-                        "Name": "CPU",
-                        "Description": "CPU Usage per Cluster (Critical)",
+                        "Name": "CPUVeryCritical",
+                        "Description": "CPU Usage per Cluster (Very Critical)",
                         "Metric": "EffectiveCpuAverage",
                         "SplitDimension": "clustername",
                         "Threshold": "[parameters('CPUVeryCriticalThreshold')]",

--- a/AVS-Landing-Zone/GreenField/PortalUI/ARM/ESLZDeploy.deploy.json
+++ b/AVS-Landing-Zone/GreenField/PortalUI/ARM/ESLZDeploy.deploy.json
@@ -1918,15 +1918,11 @@
                     },
                     "CPUCriticalThreshold": {
                       "type": "int",
-                      "defaultValue": 80
-                    },
-                    "CPUVeryCriticalThreshold": {
-                      "type": "int",
                       "defaultValue": 95
                     },
                     "MemoryCriticalThreshold": {
                       "type": "int",
-                      "defaultValue": 80
+                      "defaultValue": 95
                     },
                     "StorageCriticalThreshold": {
                       "type": "int",
@@ -1945,14 +1941,6 @@
                         "SplitDimension": "clustername",
                         "Threshold": "[parameters('CPUUsageThreshold')]",
                         "Severity": 2
-                      },
-                      {
-                        "Name": "CPUVeryCritical",
-                        "Description": "CPU Usage per Cluster (Very Critical)",
-                        "Metric": "EffectiveCpuAverage",
-                        "SplitDimension": "clustername",
-                        "Threshold": "[parameters('CPUVeryCriticalThreshold')]",
-                        "Severity": 0
                       },
                       {
                         "Name": "Memory",

--- a/AVS-Landing-Zone/GreenField/PortalUI/Bicep/Modules/Monitoring/MetricAlerts.bicep
+++ b/AVS-Landing-Zone/GreenField/PortalUI/Bicep/Modules/Monitoring/MetricAlerts.bicep
@@ -4,9 +4,8 @@ param PrivateCloudResourceId string
 param CPUUsageThreshold int
 param MemoryUsageThreshold int
 param StorageUsageThreshold int
-param CPUCriticalThreshold int = 80
-param CPUVeryCriticalThreshold int = 95
-param MemoryCriticalThreshold int = 80
+param CPUCriticalThreshold int = 95
+param MemoryCriticalThreshold int = 95
 param StorageCriticalThreshold int = 75
 param tags object
 
@@ -18,14 +17,6 @@ var Alerts = [
     SplitDimension: 'clustername'
     Threshold: CPUUsageThreshold
     Severity: 2
-  }
-  {
-    Name: 'CPUVeryCritical'
-    Description: 'CPU Usage per Cluster (Very Critical)'
-    Metric: 'EffectiveCpuAverage'
-    SplitDimension: 'clustername'
-    Threshold: CPUVeryCriticalThreshold
-    Severity: 0
   }
   {
     Name: 'Memory'

--- a/AVS-Landing-Zone/GreenField/PortalUI/Bicep/Modules/Monitoring/MetricAlerts.bicep
+++ b/AVS-Landing-Zone/GreenField/PortalUI/Bicep/Modules/Monitoring/MetricAlerts.bicep
@@ -20,8 +20,8 @@ var Alerts = [
     Severity: 2
   }
   {
-    Name: 'CPU'
-    Description: 'CPU Usage per Cluster (Critical)'
+    Name: 'CPUVeryCritical'
+    Description: 'CPU Usage per Cluster (Very Critical)'
     Metric: 'EffectiveCpuAverage'
     SplitDimension: 'clustername'
     Threshold: CPUVeryCriticalThreshold

--- a/BrownField/Monitoring/AVS-Monitoring-PortalUI/ARM/ESLZDeploy.deploy.json
+++ b/BrownField/Monitoring/AVS-Monitoring-PortalUI/ARM/ESLZDeploy.deploy.json
@@ -358,11 +358,11 @@
                     },
                     "CPUCriticalThreshold": {
                       "type": "int",
-                      "defaultValue": 80
+                      "defaultValue": 95
                     },
                     "MemoryCriticalThreshold": {
                       "type": "int",
-                      "defaultValue": 80
+                      "defaultValue": 95
                     },
                     "StorageCriticalThreshold": {
                       "type": "int",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Pull Request fixes an issue when deploying AVS using Azure Portal UI and enabling Monitoring Alerts.

## This PR fixes/adds/changes/removes

1. This PR fixes the issue #314 

### Breaking Changes

1. No breaking change

## Testing Evidence

<img width="1310" alt="image" src="https://github.com/user-attachments/assets/44e4c824-5bde-4cd8-bfb7-647c04fb9f95" />

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale-for-AVS/pulls)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale-for-AVS/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
