### PR TITLE
Fixing Trivy permissions issue.

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -9,6 +9,9 @@ jobs:
   trivy-scanning-job:
     name: trivy-sec-scan
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Related to the PR #330. Adding permissions to Trivy to allow it to publish SARIF results to the Security tab.

## This PR fixes:

1. Trivy action to publish SARIF results to the Security tab.

### Breaking Changes

N/A

## Testing Evidence

N/A

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale-for-AVS/pulls)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale-for-AVS/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
