### PR TITLE
Adding pinned-dependencies to the GitHub Actions.

### DIFF
--- a/.github/workflows/armbuild.yml
+++ b/.github/workflows/armbuild.yml
@@ -6,9 +6,9 @@ jobs:
     name: ARM
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Run Build-ARM.ps1
-      uses: azure/powershell@v2
+      uses: azure/powershell@53dd145408794f7e80f97cfcca04155c85234709 # v2.0.0
       with:
         inlineScript: |
           ./Build-ARM.ps1

--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -14,12 +14,12 @@
     
         steps:
           - name: Checkout code
-            uses: actions/checkout@v4
+            uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             with:
               fetch-depth: 0
     
           - name: Lint AVS-Landing-Zone directory
-            uses: docker://github/super-linter:v4.9.5
+            uses: docker://github/super-linter:v4.9.5@sha256:f8464fa5488596e8c996cbef5b80f1c6ff069b2eb7bc13befcdcf9bd1251ad5e
             env:
               # Only lint changed files
               VALIDATE_ALL_CODEBASE: false
@@ -43,7 +43,7 @@
               ENABLE_GITHUB_ACTIONS_STEP_SUMMARY: true
     
           - name: Lint Brownfield directory
-            uses: docker://github/super-linter:v4.9.5
+            uses: docker://github/super-linter:v4.9.5@sha256:f8464fa5488596e8c996cbef5b80f1c6ff069b2eb7bc13befcdcf9bd1251ad5e
             env:
               # Only lint changed files
               VALIDATE_ALL_CODEBASE: false
@@ -68,7 +68,7 @@
               ENABLE_GITHUB_ACTIONS_STEP_SUMMARY: true
 
           - name: Lint hcx directory
-            uses: docker://github/super-linter:v4.9.5
+            uses: docker://github/super-linter:v4.9.5@sha256:f8464fa5488596e8c996cbef5b80f1c6ff069b2eb7bc13befcdcf9bd1251ad5e
             env:
               # Only lint changed files
               VALIDATE_ALL_CODEBASE: false
@@ -93,7 +93,7 @@
               ENABLE_GITHUB_ACTIONS_STEP_SUMMARY: true
 
           - name: Lint Network Design Guide directory
-            uses: docker://github/super-linter:v4.9.5
+            uses: docker://github/super-linter:v4.9.5@sha256:f8464fa5488596e8c996cbef5b80f1c6ff069b2eb7bc13befcdcf9bd1251ad5e
             env:
               # Only lint changed files
               VALIDATE_ALL_CODEBASE: false
@@ -118,7 +118,7 @@
               ENABLE_GITHUB_ACTIONS_STEP_SUMMARY: true
 
           - name: Lint terraform directory
-            uses: docker://github/super-linter:v4.9.5
+            uses: docker://github/super-linter:v4.9.5@sha256:f8464fa5488596e8c996cbef5b80f1c6ff069b2eb7bc13befcdcf9bd1251ad5e
             env:
               # Only lint changed files
               VALIDATE_ALL_CODEBASE: false

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -6,8 +6,8 @@ jobs:
     name: Spellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: rojopolis/spellcheck-github-actions@0.46.0
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: rojopolis/spellcheck-github-actions@e7d2b8d65030d75d79a50c069a6ef30522e534eb # 0.46.0
       name: Spellcheck
       with:
         config_path: .github/config/.spellcheck.yml

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -14,10 +14,10 @@ jobs:
       actions: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # 0.28.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true
@@ -26,6 +26,6 @@ jobs:
           severity: 'HIGH,CRITICAL'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@b6a472f63d85b9c78a3ac5e89422239fc15e9b3c # v3.28.1
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -25,13 +25,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: ${{ env.wiki_source_repo }}
           path: ${{ env.wiki_source_repo }}
 
       - name: Checkout Wiki Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: ${{ env.wiki_target_repo }}
           path: ${{ env.wiki_target_repo }}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Adding pinned-dependencies to the GitHub Actions.

A "pinned dependency" is a dependency that is explicitly set to a specific hash instead of allowing a mutable version or range of versions
Pinned dependencies reduce several security risks:
* They ensure that checking and deployment are all done with the same software, reducing deployment risks, simplifying debugging, and enabling reproducibility.
* They can help mitigate compromised dependencies from undermining the security of the project.
* They are one way to counter dependency confusion (aka substitution) attacks, in which an application uses multiple feeds to acquire software packages (a "hybrid configuration"), and attackers fool the user into using a malicious package via a feed that was not expected for that package.

## This PR adds

1. Pinned dependencies to the GitHub Actions.

### Breaking Changes

N/A

## Testing Evidence

N/A

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale-for-AVS/pulls)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale-for-AVS/tree/main)
- [ ] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
