### PR TITLE
Changed ArmApiControl path to get VNetGW on the selected VNet Subscrition

### DIFF
--- a/AVS-Landing-Zone/GreenField/PortalUI/ARM/ESLZdeploy.PortalUI.json
+++ b/AVS-Landing-Zone/GreenField/PortalUI/ARM/ESLZdeploy.PortalUI.json
@@ -379,7 +379,7 @@
                             "type": "Microsoft.Solutions.ArmApiControl",
                             "request": {
                                 "method": "GET",
-                                "path": "[concat(steps('basics').avsDeploymentScope.subscription.id, '/providers/Microsoft.Network/virtualNetworkGateways?api-version=2022-11-01')]"
+                                "path": "[concat('/subscriptions/', substring(steps('azureNetwork').VnetSelectorId.id, 15, 36), '/providers/Microsoft.Network/virtualNetworkGateways?api-version=2022-11-01')]"
                             }
                         },
                         {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Fixing a Portal UI bug that, in the Azure Connectivity tab, was not allowing the selection of a VNet Gateway on a different Subscription that the one where the AVS is being deployed.

## This PR fixes/adds/changes/removes

1. Fixes a bug described on Issue #340.

### Breaking Changes

1. No breaking changes

## Testing Evidence

Provided in the related ADO Item.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale-for-AVS/pulls)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale-for-AVS/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
