### PR TITLE
Fix link for HCX Service Mesh deployment script in README.md

### DIFF
--- a/hcx/README.md
+++ b/hcx/README.md
@@ -16,4 +16,4 @@ You can find official VMware HCX documentation in VMware documentation page: [VM
 | [Networking and Network Extension Considerations](netextconsiderations.md) | Options for networking setups for migrations and HCX Network Extension considerations. |
 | [HCX Migrations](./HCX-Migrations/README.md) | Explanation of HCX Migration types. |
 | [Automated deployment and configuration for HCX Connector](../hcx/deployment/connector/README.md) | Powershell script to deploy and configure HCX Connector. |
- [Automated deployment and configuration for HCX Service Mesh](../hcx/deployment/connector/README.md) | Powershell script to deploy and configure HCX Service Mesh.
+ [Automated deployment and configuration for HCX Service Mesh](../hcx/deployment/servicemesh/readme.md) | Powershell script to deploy and configure HCX Service Mesh.


### PR DESCRIPTION
Update the link for the HCX Service Mesh deployment script to point to the correct README file.