### PR TITLE
Fix Get-Tokens function to include SubscriptionId in Connect-AzAccount call

### DIFF
--- a/BrownField/Auto-assessment/scripts/Get-Tokens.ps1
+++ b/BrownField/Auto-assessment/scripts/Get-Tokens.ps1
@@ -6,7 +6,7 @@ function Get-Tokens {
 
     try {
         # Connect to Azure account and set the context to a specific subscription
-        Connect-AzAccount -TenantId $tenantId -ErrorAction Stop
+        Connect-AzAccount -TenantId $tenantId -SubscriptionId $subscriptionId -ErrorAction Stop
         Set-AzContext -Tenant $tenantId -SubscriptionId $subscriptionId -ErrorAction Stop
 
         # Get the Azure session token

--- a/BrownField/Auto-assessment/scripts/Main.ps1
+++ b/BrownField/Auto-assessment/scripts/Main.ps1
@@ -1,3 +1,4 @@
+Set-Location -Path $PSScriptRoot
 . ./Install-ifNotExist-RequiredModules.ps1
 . ./New-IfNotExist-AzureToken.ps1
 . ./Invoke-APIRequest.ps1


### PR DESCRIPTION
Fix Get-Tokens function to include SubscriptionId in Connect-AzAccount call
Set folder in Main.ps1 to $PSScriptRoot to always find relatively addressed modules and function code

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

With an existing auth context to a different tenant the Auto-assessment script fails in function Get-Tokens in Connect-AzAccount because the subscription parameter is missing.

This is how Connect-AzAccount behaves in this case:
<img width="1558" height="736" alt="image" src="https://github.com/user-attachments/assets/61b715c3-df37-4f29-8c4e-32c92cc77d9e" />

Additionally, the script fails in Main.ps1 to load the relatively addressed modules and codes, if called from another folder. This is fixed by setting the current folder to the script's folder-

## This PR fixes/adds/changes/removes

1. Add the subscription parameter to the call of Connect-AzAccount in Get-Tokens.ps1
2. Set the current folder to the folder of Main.ps1

### Breaking Changes

N/A

## Testing Evidence

<img width="1614" height="687" alt="image" src="https://github.com/user-attachments/assets/d3585bb4-21d2-4c5a-b61d-c9366e55ea28" />

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale-for-AVS/pulls)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale-for-AVS/tree/main)
- [X] Performed testing and provided evidence.
- [X] Updated relevant and associated documentation.
